### PR TITLE
Fix tooltip evidences.

### DIFF
--- a/snippets/data/features.json
+++ b/snippets/data/features.json
@@ -1,6568 +1,5060 @@
 {
+
   "accession": "P05067",
   "entryName": "A4_HUMAN",
   "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVREVCSEQAETGPCRAMISRWYFDVTEGKCAPFFYGGCGGNRNNFDTEEYCMAVCGSAMSQSLLKTTQEPLARDPVKLPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
   "sequenceChecksum": "A12EE761403740F5",
-  "moleculeProcessing": {
-    "label": "Molecule processing",
-    "features": [
-      {
-        "type": {
-          "name": "SIGNAL",
-          "label": "signal peptide"
-        },
-        "description": "",
-        "begin": "1",
-        "end": "17",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "12665801",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/12665801"
-              },
-              {
-                "name": "PubMed",
-                "id": "2900137",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/2900137"
-              },
-              {
-                "name": "PubMed",
-                "id": "3597385",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/3597385"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000088",
-        "description": "Amyloid beta A4 protein",
-        "begin": "18",
-        "end": "770"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000089",
-        "description": "Soluble APP-alpha",
-        "begin": "18",
-        "end": "687"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000090",
-        "description": "Soluble APP-beta",
-        "begin": "18",
-        "end": "671"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000381966",
-        "description": "N-APP",
-        "begin": "18",
-        "end": "286"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000091",
-        "description": "C99",
-        "begin": "672",
-        "end": "770"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000092",
-        "description": "Beta-amyloid protein 42",
-        "begin": "672",
-        "end": "713"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000093",
-        "description": "Beta-amyloid protein 40",
-        "begin": "672",
-        "end": "711"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000094",
-        "description": "C83",
-        "begin": "688",
-        "end": "770"
-      },
-      {
-        "type": {
-          "name": "PEPTIDE",
-          "label": "peptide"
-        },
-        "ftId": "PRO_0000000095",
-        "description": "P3(42)",
-        "begin": "688",
-        "end": "713"
-      },
-      {
-        "type": {
-          "name": "PEPTIDE",
-          "label": "peptide"
-        },
-        "ftId": "PRO_0000000096",
-        "description": "P3(40)",
-        "begin": "688",
-        "end": "711"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000384574",
-        "description": "C80",
-        "begin": "691",
-        "end": "770"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000097",
-        "description": "Gamma-secretase C-terminal fragment 59",
-        "begin": "712",
-        "end": "770"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000098",
-        "description": "Gamma-secretase C-terminal fragment 57",
-        "begin": "714",
-        "end": "770"
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000099",
-        "description": "Gamma-secretase C-terminal fragment 50",
-        "begin": "721",
-        "end": "770",
-        "evidences": [
-          {
-            "code": "ECO:0000250"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CHAIN",
-          "label": "chain"
-        },
-        "ftId": "PRO_0000000100",
-        "description": "C31",
-        "begin": "740",
-        "end": "770"
-      }
-    ]
-  },
-  "structural": {
-    "label": "Structural features",
-    "features": [
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "26",
-        "end": "28",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "33",
-        "end": "35",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "43",
-        "end": "45",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "TURN",
-          "label": "turn"
-        },
-        "begin": "47",
-        "end": "49",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "52",
-        "end": "54",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "56",
-        "end": "58",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "66",
-        "end": "76",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "82",
-        "end": "87",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "92",
-        "end": "94",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "97",
-        "end": "99",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "TURN",
-          "label": "turn"
-        },
-        "begin": "100",
-        "end": "102",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "103",
-        "end": "106",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "110",
-        "end": "112",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "115",
-        "end": "119",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "134",
-        "end": "139",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "147",
-        "end": "160",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "163",
-        "end": "174",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "TURN",
-          "label": "turn"
-        },
-        "begin": "175",
-        "end": "177",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "178",
-        "end": "188",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "288",
-        "end": "292",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "299",
-        "end": "301",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "304",
-        "end": "310",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "TURN",
-          "label": "turn"
-        },
-        "begin": "311",
-        "end": "314",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "315",
-        "end": "321",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "323",
-        "end": "325",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "331",
-        "end": "333",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "334",
-        "end": "341",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "374",
-        "end": "380",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "389",
-        "end": "418",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "421",
-        "end": "423",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "425",
-        "end": "480",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "482",
-        "end": "484",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "487",
-        "end": "518",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "520",
-        "end": "546",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "547",
-        "end": "550",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "552",
-        "end": "566",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "673",
-        "end": "675",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "676",
-        "end": "678",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "679",
-        "end": "682",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "683",
-        "end": "685",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "688",
-        "end": "691",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "695",
-        "end": "697",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "698",
-        "end": "700",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "702",
-        "end": "705",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "707",
-        "end": "712",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "HELIX",
-          "label": "helix"
-        },
-        "begin": "744",
-        "end": "754",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "755",
-        "end": "758",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "STRAND",
-          "label": "strand"
-        },
-        "begin": "763",
-        "end": "765",
-        "evidences": [
-          {
-            "code": "ECO:0000244"
-          }
-        ]
-      }
-    ]
-  },
-  "domainsAndSites": {
-    "label": "Domains & sites",
-    "features": [
-      {
-        "type": {
-          "name": "DOMAIN",
-          "label": "domain"
-        },
-        "description": "BPTI/Kunitz inhibitor",
-        "begin": "291",
-        "end": "341",
-        "evidences": [
-          {
-            "code": "ECO:0000255"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "REGION",
-          "label": "region of interest"
-        },
-        "description": "Heparin-binding",
-        "begin": "96",
-        "end": "110"
-      },
-      {
-        "type": {
-          "name": "REGION",
-          "label": "region of interest"
-        },
-        "description": "Zinc-binding",
-        "begin": "181",
-        "end": "188"
-      },
-      {
-        "type": {
-          "name": "REGION",
-          "label": "region of interest"
-        },
-        "description": "Heparin-binding",
-        "begin": "391",
-        "end": "423"
-      },
-      {
-        "type": {
-          "name": "REGION",
-          "label": "region of interest"
-        },
-        "description": "Heparin-binding",
-        "begin": "491",
-        "end": "522"
-      },
-      {
-        "type": {
-          "name": "REGION",
-          "label": "region of interest"
-        },
-        "description": "Collagen-binding",
-        "begin": "523",
-        "end": "540"
-      },
-      {
-        "type": {
-          "name": "REGION",
-          "label": "region of interest"
-        },
-        "description": "Interaction with G(o)-alpha",
-        "begin": "732",
-        "end": "751"
-      },
-      {
-        "type": {
-          "name": "MOTIF",
-          "label": "short sequence motif"
-        },
-        "description": "Basolateral sorting signal",
-        "begin": "724",
-        "end": "734"
-      },
-      {
-        "type": {
-          "name": "MOTIF",
-          "label": "short sequence motif"
-        },
-        "description": "NPXY motif; contains endocytosis signal",
-        "begin": "759",
-        "end": "762"
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper 1",
-        "begin": "147",
-        "end": "147"
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper 1",
-        "begin": "151",
-        "end": "151"
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper 1",
-        "begin": "168",
-        "end": "168"
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper or zinc 2",
-        "begin": "677",
-        "end": "677"
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper or zinc 2",
-        "begin": "681",
-        "end": "681",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper or zinc 2",
-        "begin": "684",
-        "end": "684"
-      },
-      {
-        "type": {
-          "name": "METAL",
-          "label": "metal ion-binding site"
-        },
-        "description": "Copper or zinc 2",
-        "begin": "685",
-        "end": "685"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Required for Cu(2+) reduction",
-        "begin": "144",
-        "end": "144"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Reactive bond",
-        "begin": "301",
-        "end": "302"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by beta-secretase",
-        "begin": "671",
-        "end": "672"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by caspase-6; when associated with variant 670-N-L-671",
-        "begin": "672",
-        "end": "673"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by alpha-secretase",
-        "begin": "687",
-        "end": "688"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by theta-secretase",
-        "begin": "690",
-        "end": "691"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Implicated in free radical propagation",
-        "begin": "704",
-        "end": "704",
-        "evidences": [
-          {
-            "code": "ECO:0000250"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Susceptible to oxidation",
-        "begin": "706",
-        "end": "706",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10535332",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10535332"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by gamma-secretase; site 1",
-        "begin": "711",
-        "end": "712"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by gamma-secretase; site 2",
-        "begin": "713",
-        "end": "714"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by gamma-secretase; site 3",
-        "begin": "720",
-        "end": "721"
-      },
-      {
-        "type": {
-          "name": "SITE",
-          "label": "site"
-        },
-        "description": "Cleavage; by caspase-6, caspase-8 or caspase-9",
-        "begin": "739",
-        "end": "740"
-      },
-      {
-        "type": {
-          "name": "DOMAIN",
-          "label": "domain"
-        },
-        "description": "P53_TAD",
-        "begin": "605",
-        "end": "629",
-        "evidences": [
-          {
-            "code": "ECO:0000259",
-            "sources": [
-              {
-                "name": "Pfam",
-                "id": "PF08563",
-                "url": "http://pfam.xfam.org/family/PF08563"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type":
+  "taxid" : 9606,
+  "features":
+
+  [
+
+    {
+
+      "type": "SIGNAL",
+      "category": "MOLECULE_PROCESSING",
+      "description": "",
+      "begin": "1",
+      "end": "17",
+      "evidences":
+
+      [
+
         {
-          "name": "DOMAIN",
-          "label": "domain"
-        },
-        "description": "C2 1",
-        "begin": "421",
-        "end": "525",
-        "evidences":
-        [
-          {
-            "code": "ECO:0000255",
-            "sources":
-            [
-              {
-                "name": "PROSITE-ProRule",
-                "id": "PRU00041",
-                "url": "http://prosite.expasy.org/unirule/PRU00041"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "ptm": {
-    "label": "Post translational modifications",
-    "features": [
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphoserine; by CK2",
-        "begin": "198",
-        "end": "198",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "8999878",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphoserine; by CK1",
-        "begin": "206",
-        "end": "206",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "8999878",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphoserine; by FAM20C",
-        "begin": "441",
-        "end": "441",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "26091039",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/26091039"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphotyrosine",
-        "begin": "497",
-        "end": "497",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "26091039",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/26091039"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphothreonine",
-        "begin": "729",
-        "end": "729",
-        "evidences": [
-          {
-            "code": "ECO:0000250",
-            "sources": [
-              {
-                "name": "UniProtKB",
-                "id": "P08592",
-                "url": "http://www.uniprot.org/uniprot/P08592"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphoserine; by APP-kinase I",
-        "begin": "730",
-        "end": "730",
-        "evidences": [
-          {
-            "code": "ECO:0000250"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphothreonine; by CDK5 and MAPK10",
-        "begin": "743",
-        "end": "743",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "8131745",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8131745"
-              }
-            ]
-          },
-          {
-            "code": "ECO:0000244",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "24275569",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/24275569"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MOD_RES",
-          "label": "modified residue"
-        },
-        "description": "Phosphotyrosine",
-        "begin": "757",
-        "end": "757",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11877420",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "542",
-        "end": "542",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "16335952",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/16335952"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "571",
-        "end": "571",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "614",
-        "end": "614",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "22576872",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "623",
-        "end": "623",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "22576872",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "628",
-        "end": "628",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "22576872",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "633",
-        "end": "633",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "21712440",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "651",
-        "end": "651",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "21712440",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "652",
-        "end": "652",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "21712440",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "in L-APP isoforms",
-        "begin": "656",
-        "end": "656",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "21712440",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "659",
-        "end": "659"
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "663",
-        "end": "663",
-        "evidences": [
-          {
-            "code": "ECO:0000305",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "21712440",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "667",
-        "end": "667",
-        "evidences": [
-          {
-            "code": "ECO:0000305",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "21712440",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "679",
-        "end": "679",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "22576872",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CARBOHYD",
-          "label": "glycosylation site"
-        },
-        "description": "",
-        "begin": "697",
-        "end": "697",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "22576872",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "38",
-        "end": "62"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "73",
-        "end": "117"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "98",
-        "end": "105"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "133",
-        "end": "187"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "144",
-        "end": "174"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "158",
-        "end": "186"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "291",
-        "end": "341"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "300",
-        "end": "324"
-      },
-      {
-        "type": {
-          "name": "DISULFID",
-          "label": "disulfide bond"
-        },
-        "description": "",
-        "begin": "316",
-        "end": "337"
-      },
-      {
-        "type": {
-          "name": "CROSSLNK",
-          "label": "cross-link"
-        },
-        "description": "Glycyl lysine isopeptide (Lys-Gly) (interchain with G-Cter in ubiquitin)",
-        "begin": "763",
-        "end": "763",
-        "evidences": [
-          {
-            "code": "ECO:0000250",
-            "sources": [
-              {
-                "name": "UniProtKB",
-                "id": "P08592",
-                "url": "http://www.uniprot.org/uniprot/P08592"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "mutagenesis": {
-    "label": "Mutagenesis",
-    "features": [
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced heparin-binding",
-        "mutation": "NQGG",
-        "begin": "99",
-        "end": "102",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "8158260",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8158260"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Binds copper. Forms dimer",
-        "mutation": "N",
-        "begin": "137",
-        "end": "137",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Binds copper. Forms dimer",
-        "mutation": "T",
-        "begin": "141",
-        "end": "141",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Binds copper. No dimer formation. No copper reducing activity",
-        "mutation": "S",
-        "begin": "144",
-        "end": "144",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10461923",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10461923"
-              },
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "50% decrease in copper reducing activity",
-        "mutation": "ALA",
-        "begin": "147",
-        "end": "149",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10461923",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10461923"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Some decrease in copper reducing activity",
-        "mutation": "A",
-        "begin": "147",
-        "end": "147",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11784781",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781"
-              },
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Binds copper. Forms dimer",
-        "mutation": "N",
-        "begin": "147",
-        "end": "147",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11784781",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781"
-              },
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Greatly reduced copper-mediated low-density lipoprotein oxidation",
-        "mutation": "Y",
-        "begin": "147",
-        "end": "147",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11784781",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781"
-              },
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Greatly reduced copper-mediated low-density lipoprotein oxidation",
-        "mutation": "K",
-        "begin": "151",
-        "end": "151",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11784781",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781"
-              },
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Binds copper. Forms dimer",
-        "mutation": "N",
-        "begin": "151",
-        "end": "151",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11784781",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781"
-              },
-              {
-                "name": "PubMed",
-                "id": "7913895",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Greatly reduced casein kinase phosphorylation",
-        "mutation": "A",
-        "begin": "198",
-        "end": "198",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10806211",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10806211"
-              },
-              {
-                "name": "PubMed",
-                "id": "8999878",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced casein kinase phosphorylation",
-        "mutation": "A",
-        "begin": "206",
-        "end": "206",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10806211",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10806211"
-              },
-              {
-                "name": "PubMed",
-                "id": "8999878",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced affinity for heparin; when associated with A-503",
-        "mutation": "A",
-        "begin": "499",
-        "end": "499",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "15304215",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15304215"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced affinity for heparin; when associated with A-499",
-        "mutation": "A",
-        "begin": "503",
-        "end": "503",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "15304215",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15304215"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Abolishes chondroitin sulfate binding in L-APP733 isoform",
-        "mutation": "A",
-        "begin": "656",
-        "end": "656",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "7737970",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/7737970"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "60-70% zinc-induced beta-APP (28) peptide aggregation",
-        "mutation": "G",
-        "begin": "676",
-        "end": "676",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10413512",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10413512"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "60-70% zinc-induced beta-APP (28) peptide aggregation",
-        "mutation": "F",
-        "begin": "681",
-        "end": "681",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10413512",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10413512"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Only 23% zinc-induced beta-APP (28) peptide aggregation",
-        "mutation": "R",
-        "begin": "684",
-        "end": "684",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10413512",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10413512"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced protein oxidation. No hippocampal neuron toxicity",
-        "mutation": "V",
-        "begin": "704",
-        "end": "704"
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced lipid peroxidation inhibition",
-        "mutation": "L",
-        "begin": "706",
-        "end": "706",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10535332",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10535332"
-              },
-              {
-                "name": "PubMed",
-                "id": "9168929",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/9168929"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "No free radical production. No hippocampal neuron toxicity",
-        "mutation": "V",
-        "begin": "706",
-        "end": "706",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10535332",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10535332"
-              },
-              {
-                "name": "PubMed",
-                "id": "9168929",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/9168929"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Unchanged beta-APP42/total APP-beta ratio",
-        "mutation": "C,S",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "8886002",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Increased beta-APP42/beta-APP40 ratio",
-        "mutation": "F,G,I",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "8886002",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Decreased beta-APP42/total APP-beta ratio",
-        "mutation": "K",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "8886002",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Increased beta-APP42/beta-APP40 ratio. No change in apoptosis after caspase cleavage",
-        "mutation": "M",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "8886002",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "No effect on APBA1 nor APBB1 binding. Greatly reduces the binding to APPBP2. APP internalization unchanged. No change in beta-APP42 secretion",
-        "mutation": "A",
-        "begin": "728",
-        "end": "728",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              },
-              {
-                "name": "PubMed",
-                "id": "8887653",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653"
-              },
-              {
-                "name": "PubMed",
-                "id": "9843960",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/9843960"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "No cleavage by caspases during apoptosis",
-        "mutation": "A",
-        "begin": "739",
-        "end": "739",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10319819",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10319819"
-              },
-              {
-                "name": "PubMed",
-                "id": "10742146",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10742146"
-              },
-              {
-                "name": "PubMed",
-                "id": "12214090",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/12214090"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "No effect on FADD-induced apoptosis",
-        "mutation": "N",
-        "begin": "739",
-        "end": "739",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10319819",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10319819"
-              },
-              {
-                "name": "PubMed",
-                "id": "10742146",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10742146"
-              },
-              {
-                "name": "PubMed",
-                "id": "12214090",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/12214090"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Greatly reduces the binding to SHC1 and APBB family members; no effect on NGF-stimulated neurite extension",
-        "mutation": "A",
-        "begin": "743",
-        "end": "743",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10341243",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10341243"
-              },
-              {
-                "name": "PubMed",
-                "id": "11146006",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11146006"
-              },
-              {
-                "name": "PubMed",
-                "id": "11517218",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11517218"
-              },
-              {
-                "name": "PubMed",
-                "id": "11877420",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Reduced NGF-stimulated neurite extension. No effect on APP maturation",
-        "mutation": "E",
-        "begin": "743",
-        "end": "743",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10341243",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10341243"
-              },
-              {
-                "name": "PubMed",
-                "id": "11146006",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11146006"
-              },
-              {
-                "name": "PubMed",
-                "id": "11517218",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11517218"
-              },
-              {
-                "name": "PubMed",
-                "id": "11877420",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "APP internalization unchanged. No change in beta-APP42 secretion",
-        "mutation": "A",
-        "begin": "756",
-        "end": "756",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Little APP internalization. Reduced beta-APP42 secretion",
-        "mutation": "A",
-        "begin": "757",
-        "end": "757",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              },
-              {
-                "name": "PubMed",
-                "id": "11724784",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11724784"
-              },
-              {
-                "name": "PubMed",
-                "id": "11877420",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420"
-              },
-              {
-                "name": "PubMed",
-                "id": "8887653",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Loss of binding to MAPK8IP1, APBA1, APBB1, APPBP2 and SHC1",
-        "mutation": "G",
-        "begin": "757",
-        "end": "757",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              },
-              {
-                "name": "PubMed",
-                "id": "11724784",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11724784"
-              },
-              {
-                "name": "PubMed",
-                "id": "11877420",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420"
-              },
-              {
-                "name": "PubMed",
-                "id": "8887653",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "No binding to APBA1, no effect on APBB1 binding. Little APP internalization. Reduced beta-APP42 secretion",
-        "mutation": "A",
-        "begin": "759",
-        "end": "759",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              },
-              {
-                "name": "PubMed",
-                "id": "8887653",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Little APP internalization. Reduced beta-APP42 secretion",
-        "mutation": "A",
-        "begin": "760",
-        "end": "760",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "MUTAGEN",
-          "label": "mutagenesis site"
-        },
-        "description": "Loss of binding to APBA1 and APBB1. APP internalization unchanged. No change in beta-APP42 secretion",
-        "mutation": "A",
-        "begin": "762",
-        "end": "762",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10383380",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380"
-              },
-              {
-                "name": "PubMed",
-                "id": "8887653",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "seqInfo": {
-    "label": "Sequence information",
-    "features": [
-      {
-        "type": {
-          "name": "COMPBIAS",
-          "label": "compositionally biased region"
-        },
-        "description": "Asp/Glu-rich (acidic)",
-        "begin": "230",
-        "end": "260"
-      },
-      {
-        "type": {
-          "name": "COMPBIAS",
-          "label": "compositionally biased region"
-        },
-        "description": "Poly-Thr",
-        "begin": "274",
-        "end": "280"
-      },
-      {
-        "type": {
-          "name": "CONFLICT",
-          "label": "sequence conflict"
-        },
-        "description": "in Ref. 3; CAA31830",
-        "alternativeSequence": "VW",
-        "begin": "15",
-        "end": "16",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CONFLICT",
-          "label": "sequence conflict"
-        },
-        "description": "in Ref. 36; AAA51722",
-        "alternativeSequence": "E",
-        "begin": "647",
-        "end": "647",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CONFLICT",
-          "label": "sequence conflict"
-        },
-        "description": "in Ref. 23; AAB26263/AAB26264",
-        "alternativeSequence": "",
-        "begin": "724",
-        "end": "724",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CONFLICT",
-          "label": "sequence conflict"
-        },
-        "description": "in Ref. 23; AAB26263/AAB26264/ AAB26265",
-        "alternativeSequence": "N",
-        "begin": "731",
-        "end": "731",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "CONFLICT",
-          "label": "sequence conflict"
-        },
-        "description": "in Ref. 31; AAA35540",
-        "alternativeSequence": "S",
-        "begin": "757",
-        "end": "757",
-        "evidences": [
-          {
-            "code": "ECO:0000305"
-          }
-        ]
-      }
-    ]
-  },
-  "topology": {
-    "label": "Topology",
-    "features": [
-      {
-        "type": {
-          "name": "TOPO_DOM",
-          "label": "topological domain"
-        },
-        "description": "Extracellular",
-        "begin": "18",
-        "end": "699",
-        "evidences": [
-          {
-            "code": "ECO:0000255"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "TRANSMEM",
-          "label": "transmembrane region"
-        },
-        "description": "Helical",
-        "begin": "700",
-        "end": "723",
-        "evidences": [
-          {
-            "code": "ECO:0000255"
-          }
-        ]
-      },
-      {
-        "type": {
-          "name": "TOPO_DOM",
-          "label": "topological domain"
-        },
-        "description": "Cytoplasmic",
-        "begin": "724",
-        "end": "770",
-        "evidences": [
-          {
-            "code": "ECO:0000255"
-          }
-        ]
-      }
-    ]
-  },
-  "variants": {
-    "label": "Variants",
-    "features": [
-      {
-        "type": {
-          "name": "INIT_CODON",
-          "label": "init codon"
-        },
-        "mutation": "I",
-        "begin": "1",
-        "end": "1",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:482",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=482"
-              },
-              {
-                "name": "PubMed",
-                "id": "23292937",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/23292937"
-              }
-            ]
-          }
-        ],
-        "wildType": "M",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.114999995,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26170599G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "8",
-        "end": "8",
-        "description": "LSS: Any description",
-        "xrefs": [
-          {
-              "name": "cosmic",
-              "id": "COSM1580524",
-              "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1580524"
-          },
-          {
-            "name": "cosmic",
-            "id": "COSM15805",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=15805"
-          },
-          {
-            "name": "any other",
-            "id": "OTHER123",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=OTHER123"
-          },
-          {
-            "name": "cosmic",
-            "id": "COSM1580524",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1580524"
-          },
-          {
-            "id": "COSM1580524"
-          }
-        ],
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:482",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=482"
-              },
-              {
-                "name": "PubMed",
-                "id": "23292937",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/23292937"
-              }
-            ]
-          }
-        ],
-        "wildType": "L",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.114999995,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26170599G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "770",
-        "end": "770",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029630",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029630"
-          }
-        ],
-        "wildType": "F",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.99950004,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25881691G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_LOST",
-          "label": "stop lost"
-        },
-        "mutation": "S",
-        "begin": "771",
-        "end": "771",
-        "wildType": "*",
-        "frequency": 0.000199681,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "6p21.1",
-        "genomicLocation": "6:g.43054441C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "763",
-        "end": "763",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic",
-                "id": "COSM318737",
-                "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=318737"
-              }
-            ]
-          }
-        ],
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.999,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.13,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25881695T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "753",
-        "end": "753",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic",
-                "id": "COSM3841667",
-                "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=3841667"
-              }
-            ]
-          }
-        ],
-        "wildType": "Q",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25881726G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "752",
-        "end": "752",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic",
-                "id": "COSM3841668",
-                "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=3841668"
-              }
-            ]
-          }
-        ],
-        "wildType": "M",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.997,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25881727C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "P",
-        "begin": "747",
-        "end": "747",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:417",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=417"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM578783",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=578783"
-          }
-        ],
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 1,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25881743C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "C",
-        "begin": "747",
-        "end": "747",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029632",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029632"
-          }
-        ],
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 1,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25881744G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "A",
-        "begin": "729",
-        "end": "729",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:375",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=375"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1566114",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1566114"
-          },
-          {
-            "name": "dbSNP",
-            "id": "rs551889721",
-            "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs551889721"
-          }
-        ],
-        "wildType": "T",
-        "frequency": 0.000599042,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.27849996,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.035,
-        "somaticStatus": 1,
-        "cytogeneticBand": "17q21.2",
-        "genomicLocation": "17:g.41845226C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "727",
-        "end": "727",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:376",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1413494",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1413494"
-          }
-        ],
-        "wildType": "Q",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.399,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.035,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25891753T>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "Ftid: VAR_010109",
-        "mutation": "P",
-        "begin": "723",
-        "end": "723",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10665499",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10665499"
-              },
-              {
-                "name": "PubMed",
-                "id": "15201367",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15201367"
-              }
-            ]
-          }
-        ],
-        "wildType": "L",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1. Ftid: VAR_000023",
-        "mutation": "L",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10631141",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10631141"
-              },
-              {
-                "name": "PubMed",
-                "id": "10867787",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10867787"
-              },
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "1671712",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1671712"
-              },
-              {
-                "name": "PubMed",
-                "id": "1678058",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1678058"
-              },
-              {
-                "name": "PubMed",
-                "id": "1908231",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1908231"
-              },
-              {
-                "name": "PubMed",
-                "id": "1925564",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1925564"
-              },
-              {
-                "name": "PubMed",
-                "id": "1944558",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1944558"
-              },
-              {
-                "name": "PubMed",
-                "id": "8267572",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8267572"
-              },
-              {
-                "name": "PubMed",
-                "id": "8290042",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8290042"
-              },
-              {
-                "name": "PubMed",
-                "id": "8476439",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439"
-              },
-              {
-                "name": "PubMed",
-                "id": "8577393",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8577393"
-              }
-            ]
-          }
-        ],
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10631141",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10631141"
-              },
-              {
-                "name": "PubMed",
-                "id": "10867787",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10867787"
-              },
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "1671712",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1671712"
-              },
-              {
-                "name": "PubMed",
-                "id": "1678058",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1678058"
-              },
-              {
-                "name": "PubMed",
-                "id": "1908231",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1908231"
-              },
-              {
-                "name": "PubMed",
-                "id": "1925564",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1925564"
-              },
-              {
-                "name": "PubMed",
-                "id": "1944558",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1944558"
-              },
-              {
-                "name": "PubMed",
-                "id": "8267572",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8267572"
-              },
-              {
-                "name": "PubMed",
-                "id": "8290042",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8290042"
-              },
-              {
-                "name": "PubMed",
-                "id": "8476439",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439"
-              },
-              {
-                "name": "PubMed",
-                "id": "8577393",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8577393"
-              }
-            ]
-          }
-        ],
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1",
-        "mutation": "G",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10631141",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10631141"
-              },
-              {
-                "name": "PubMed",
-                "id": "10867787",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10867787"
-              },
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "1671712",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1671712"
-              },
-              {
-                "name": "PubMed",
-                "id": "1678058",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1678058"
-              },
-              {
-                "name": "PubMed",
-                "id": "1908231",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1908231"
-              },
-              {
-                "name": "PubMed",
-                "id": "1925564",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1925564"
-              },
-              {
-                "name": "PubMed",
-                "id": "1944558",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1944558"
-              },
-              {
-                "name": "PubMed",
-                "id": "8267572",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8267572"
-              },
-              {
-                "name": "PubMed",
-                "id": "8290042",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8290042"
-              },
-              {
-                "name": "PubMed",
-                "id": "8476439",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439"
-              },
-              {
-                "name": "PubMed",
-                "id": "8577393",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8577393"
-              }
-            ]
-          }
-        ],
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1",
-        "mutation": "F",
-        "begin": "717",
-        "end": "717",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10631141",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10631141"
-              },
-              {
-                "name": "PubMed",
-                "id": "10867787",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10867787"
-              },
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "1671712",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1671712"
-              },
-              {
-                "name": "PubMed",
-                "id": "1678058",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1678058"
-              },
-              {
-                "name": "PubMed",
-                "id": "1908231",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1908231"
-              },
-              {
-                "name": "PubMed",
-                "id": "1925564",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1925564"
-              },
-              {
-                "name": "PubMed",
-                "id": "1944558",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1944558"
-              },
-              {
-                "name": "PubMed",
-                "id": "8267572",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8267572"
-              },
-              {
-                "name": "PubMed",
-                "id": "8290042",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8290042"
-              },
-              {
-                "name": "PubMed",
-                "id": "8476439",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439"
-              },
-              {
-                "name": "PubMed",
-                "id": "8577393",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8577393"
-              }
-            ]
-          }
-        ],
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1",
-        "mutation": "V",
-        "begin": "716",
-        "end": "716",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "9328472",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/9328472"
-              }
-            ]
-          }
-        ],
-        "wildType": "I",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "M",
-        "begin": "715",
-        "end": "715",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "10097173",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/10097173"
-              }
-            ]
-          }
-        ],
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Alzheimer disease 1 (AD1)",
-            "description": "decreased beta-APP40/ total APP-beta",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "104300",
-                "url": "http://www.omim.org/entry/104300"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "714",
-        "end": "714",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "12034808",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/12034808"
-              },
-              {
-                "name": "PubMed",
-                "id": "15668448",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15668448"
-              }
-            ]
-          }
-        ],
-        "wildType": "T",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Alzheimer disease 1 (AD1)",
-            "description": "increased beta-APP42/ beta-APP40 ratio",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "104300",
-                "url": "http://www.omim.org/entry/104300"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1. Ftid: VAR_000714 LSS: primary tissue(s): endometrium",
-        "mutation": "A",
-        "begin": "714",
-        "end": "714",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11063718",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718"
-              },
-              {
-                "name": "PubMed",
-                "id": "12034808",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/12034808"
-              },
-              {
-                "name": "PubMed",
-                "id": "15668448",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15668448"
-              }
-            ]
-          },
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029634",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029634"
-          }
-        ],
-        "wildType": "T",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.97800004,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.01,
-        "somaticStatus": 1,
-        "disease": false,
-        "sourceType": "Mixed"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in one chronic schizophrenia patient; unknown pathological significance",
-        "mutation": "V",
-        "begin": "713",
-        "end": "713",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "1303275",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1303275"
-              },
-              {
-                "name": "PubMed",
-                "id": "1307241",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1307241"
-              },
-              {
-                "name": "PubMed",
-                "id": "15365148",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15365148"
-              }
-            ]
-          }
-        ],
-        "wildType": "A",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1; ALZHEIMER DISEASE, FAMILIAL, 1",
-        "mutation": "T",
-        "begin": "713",
-        "end": "713",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "1303275",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1303275"
-              },
-              {
-                "name": "PubMed",
-                "id": "1307241",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1307241"
-              },
-              {
-                "name": "PubMed",
-                "id": "15365148",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15365148"
-              }
-            ]
-          }
-        ],
-        "wildType": "A",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.995,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25891796C>T",
-        "clinicalSignificances": "not provided,pathogenic",
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "V",
-        "begin": "709",
-        "end": "709",
-        "wildType": "G",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.986,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25891807C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "A",
-        "begin": "709",
-        "end": "709",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:482",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=482"
-              },
-              {
-                "name": "PubMed",
-                "id": "23292937",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/23292937"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1580522",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1580522"
-          }
-        ],
-        "wildType": "G",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.9915,
-        "siftPrediction": "tolerated",
-        "siftScore": 1,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25891807C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "V",
-        "begin": "705",
-        "end": "705",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "16178030",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/16178030"
-              }
-            ]
-          }
-        ],
-        "wildType": "L",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Cerebral amyloid angiopathy, APP-related (CAA-APP)",
-            "description": "Italian type",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "605714",
-                "url": "http://www.omim.org/entry/605714"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "704",
-        "end": "704",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic",
-                "id": "COSM3549993",
-                "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=3549993"
-              }
-            ]
-          }
-        ],
-        "wildType": "G",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.998,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.01,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25891823C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "V",
-        "begin": "701",
-        "end": "701",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029635",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029635"
-          }
-        ],
-        "wildType": "A",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.9475,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25891831G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "694",
-        "end": "694",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11409420",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11409420"
-              },
-              {
-                "name": "PubMed",
-                "id": "12654973",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/12654973"
-              }
-            ]
-          }
-        ],
-        "wildType": "D",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Cerebral amyloid angiopathy, APP-related (CAA-APP)",
-            "description": "Iowa type",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "605714",
-                "url": "http://www.omim.org/entry/605714"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "693",
-        "end": "693",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11528419",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11528419"
-              },
-              {
-                "name": "PubMed",
-                "id": "1415269",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1415269"
-              },
-              {
-                "name": "PubMed",
-                "id": "2111584",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/2111584"
-              }
-            ]
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Cerebral amyloid angiopathy, APP-related (CAA-APP)",
-            "description": "Dutch type",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "605714",
-                "url": "http://www.omim.org/entry/605714"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "693",
-        "end": "693",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11528419",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11528419"
-              },
-              {
-                "name": "PubMed",
-                "id": "1415269",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1415269"
-              },
-              {
-                "name": "PubMed",
-                "id": "2111584",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/2111584"
-              }
-            ]
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Cerebral amyloid angiopathy, APP-related (CAA-APP)",
-            "description": "Italian type",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "605714",
-                "url": "http://www.omim.org/entry/605714"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "G",
-        "begin": "692",
-        "end": "692",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "11311152",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/11311152"
-              },
-              {
-                "name": "PubMed",
-                "id": "1303239",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/1303239"
-              },
-              {
-                "name": "PubMed",
-                "id": "9754958",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/9754958"
-              }
-            ]
-          }
-        ],
-        "wildType": "A",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "association": [
-          {
-            "name": "Alzheimer disease 1 (AD1)",
-            "description": "increases the solubility of processed beta-amyloid peptides and increases the stability of peptide oligomers",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "104300",
-                "url": "http://www.omim.org/entry/104300"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "D",
-        "begin": "68",
-        "end": "68",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:452",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=452"
-              },
-              {
-                "name": "PubMed",
-                "id": "22895193",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22895193"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1183278",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1183278"
-          }
-        ],
-        "wildType": "G",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.11,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26112001C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "685",
-        "end": "685",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029636",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029636"
-          }
-        ],
-        "wildType": "H",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.991,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.51,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897583T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "684",
-        "end": "684",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029637",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029637"
-          }
-        ],
-        "wildType": "H",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.83,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.31,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897585A>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "679",
-        "end": "679",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:511",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=511"
-              },
-              {
-                "name": "PubMed",
-                "id": "22842228",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22842228"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1713870",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1713870"
-          }
-        ],
-        "wildType": "S",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897601G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1",
-        "mutation": "N",
-        "begin": "678",
-        "end": "678",
-        "description": "Ftid: VAR_044424",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "15201367",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/15201367"
-              }
-            ]
-          }
-        ],
-        "wildType": "D",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "676",
-        "end": "676",
-        "xrefs": [
-          {
-            "name": "dbSNP",
-            "id": "rs559207950",
-            "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs559207950"
-          }
-        ],
-        "wildType": "R",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.643,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.37,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897610C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "674",
-        "end": "674",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1029638",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1029638"
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897617C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "671",
-        "end": "671",
-        "xrefs": [
-          {
-            "name": "dbSNP",
-            "id": "rs572842823",
-            "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs572842823"
-          }
-        ],
-        "description": "Ftid: VAR_00000",
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897626T>A",
-        "disease": false,
-        "sourceType": "Mixed"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in AD1",
-        "mutation": "GA",
-        "begin": "670",
-        "end": "671",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "668",
-        "end": "668",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:417",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=417"
-              }
-            ]
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.221,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.24000001,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897635C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "description": "in a patient with late onset Alzheimer disease. Ftid: VAR_010107",
-        "mutation": "D",
-        "begin": "665",
-        "end": "665",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "8154870",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/8154870"
-              }
-            ]
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "664",
-        "end": "664",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:376",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
-              }
-            ]
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.941,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.13499999,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897647C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "A",
-        "begin": "652",
-        "end": "652",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:419",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
-              }
-            ]
-          }
-        ],
-        "wildType": "T",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.9985,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.53499997,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25905033T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "636",
-        "end": "636",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:376",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
-              }
-            ]
-          }
-        ],
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.079,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.16,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911744C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "F",
-        "begin": "628",
-        "end": "628",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:511",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=511"
-              },
-              {
-                "name": "PubMed",
-                "id": "22842228",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/22842228"
-              }
-            ]
-          }
-        ],
-        "wildType": "S",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.861,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911767G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Y",
-        "begin": "623",
-        "end": "623",
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM3423878",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=3423878"
-          }
-        ],
-        "wildType": "S",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.629,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.05,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911782G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "F",
-        "begin": "623",
-        "end": "623",
-        "wildType": "S",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.629,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.1,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911782G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "617",
-        "end": "617",
-        "wildType": "D",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.053,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.33,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911801C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "G",
-        "begin": "614",
-        "end": "614",
-        "xrefs": [
-          {
-            "name": "dbSNP",
-            "id": "rs112263157",
-            "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs112263157"
-          }
-        ],
-        "wildType": "S",
-        "frequency": 0.00379393,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.004,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.43,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911810T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "M",
-        "begin": "609",
-        "end": "609",
-        "wildType": "V",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.815,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.14,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911825C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "M",
-        "begin": "604",
-        "end": "604",
-        "evidences": [
-          {
-            "code": "ECO:0000313",
-            "sources": [
-              {
-                "name": "cosmic_study",
-                "id": "COSU:482",
-                "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=482"
-              }
-            ]
-          },
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "23292937",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/23292937"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1580523",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1580523"
-          },
-          {
-            "name": "dbSNP",
-            "id": "rs199887707",
-            "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199887707"
-          }
-        ],
-        "wildType": "V",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.087,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.29000002,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911840C>T",
-        "disease": false,
-        "sourceType": "Mixed"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "599",
-        "end": "599",
-        "wildType": "E",
-        "frequency": 0.000599042,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.615,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.04,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911855C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "591",
-        "end": "591",
-        "wildType": "D",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.999,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911879C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "584",
-        "end": "584",
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM3549994",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=3549994"
-          }
-        ],
-        "wildType": "P",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.05,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.8,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911900G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "584",
-        "end": "584",
-        "wildType": "P",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.603,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.14,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911899G>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "V",
-        "begin": "580",
-        "end": "580",
-        "wildType": "M",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.004,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.16,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911912T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Y",
-        "begin": "574",
-        "end": "574",
-        "wildType": "D",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.64849997,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.175,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911930C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "571",
-        "end": "571",
-        "wildType": "N",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.05,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.7,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911937G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "564",
-        "end": "564",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.548,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.015,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25911960C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "D",
-        "begin": "561",
-        "end": "561",
-        "wildType": "E",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.318,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.19,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25954594T>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "556",
-        "end": "556",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.049,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.02,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25954611C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "525",
-        "end": "525",
-        "xrefs": [
-          {
-            "name": "cosmic",
-            "id": "COSM1751585",
-            "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1751585"
-          }
-        ],
-        "wildType": "Q",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955641G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "51",
-        "end": "51",
-        "wildType": "K",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26112051C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "513",
-        "end": "513",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.99,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955677C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "501",
-        "end": "501",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "disease": false,
-        "sourceType": "UniProt"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "C",
-        "begin": "499",
-        "end": "499",
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.99950004,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955719G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "498",
-        "end": "498",
-        "wildType": "V",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.66625,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.1425,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25954600C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "492",
-        "end": "492",
-        "wildType": "N",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.02,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.51,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955739T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "491",
-        "end": "491",
-        "wildType": "F",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.078,
-        "siftPrediction": "tolerated",
-        "siftScore": 1,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955741G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "M",
-        "begin": "490",
-        "end": "490",
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.995,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955746C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "C",
-        "begin": "488",
-        "end": "488",
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.9515,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25955752G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "486",
-        "end": "486",
-        "wildType": "R",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.045,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.39,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975071C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "484",
-        "end": "484",
-        "wildType": "P",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.13949999,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.065,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975078G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "H",
-        "begin": "470",
-        "end": "470",
-        "wildType": "R",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.999,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975119C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "H",
-        "begin": "469",
-        "end": "469",
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 1,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975122C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "449",
-        "end": "449",
-        "wildType": "E",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.962,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975183C>T",
-        "disease": false,
-        "sourceType": "Mixed"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Y",
-        "begin": "441",
-        "end": "441",
-        "wildType": "S",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.8475,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975206G>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "E",
-        "begin": "438",
-        "end": "438",
-        "wildType": "K",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.884,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.07,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975216T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "E",
-        "begin": "436",
-        "end": "436",
-        "wildType": "Q",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.898,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975222G>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "436",
-        "end": "436",
-        "wildType": "Q",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975222G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "429",
-        "end": "429",
-        "wildType": "K",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.999,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.01,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975967T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "E",
-        "begin": "428",
-        "end": "428",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.999,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975971T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "421",
-        "end": "421",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.949,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.02,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25975990C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "C",
-        "begin": "418",
-        "end": "418",
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.638,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.075,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25976001G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "417",
-        "end": "417",
-        "wildType": "E",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.934,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25976004C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "404",
-        "end": "404",
-        "wildType": "E",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.986,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.07,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25982358C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "399",
-        "end": "399",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.99950004,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25982373C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "E",
-        "begin": "393",
-        "end": "393",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.92149997,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.005,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25982391T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "386",
-        "end": "386",
-        "wildType": "N",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.241,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.31,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25982411T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "377",
-        "end": "377",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.03,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.795,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25982438T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "375",
-        "end": "375",
-        "wildType": "V",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.42,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.04,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25982445C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "365",
-        "end": "365",
-        "wildType": "P",
-        "frequency": 0.00159744,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.935,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.13,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25897627C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "359",
-        "end": "359",
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.001,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.58000004,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25997374C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "V",
-        "begin": "358",
-        "end": "358",
-        "wildType": "A",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.002,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.52,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25997377G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "F",
-        "begin": "357",
-        "end": "357",
-        "wildType": "L",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.004,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.26500002,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.25997381G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "T",
-        "begin": "344",
-        "end": "344",
-        "wildType": "A",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.101,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.29,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000018C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "316",
-        "end": "316",
-        "wildType": "C",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000100A>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "315",
-        "end": "315",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.9,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000103C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "308",
-        "end": "308",
-        "wildType": "Y",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000124G>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "303",
-        "end": "303",
-        "wildType": "M",
-        "frequency": 0,
-        "polyphenPrediction": "possibly damaging",
-        "polyphenScore": 0.593,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.19,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000139C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "G",
-        "begin": "301",
-        "end": "301",
-        "wildType": "R",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.931,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000147G>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "299",
-        "end": "299",
-        "wildType": "P",
-        "frequency": 0,
-        "polyphenPrediction": "probably damaging",
-        "polyphenScore": 0.952,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000152G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "M",
-        "begin": "297",
-        "end": "297",
-        "wildType": "T",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.53925,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.022499999,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26000158G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "P",
-        "begin": "28",
-        "end": "28",
-        "wildType": "L",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.085,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26112121A>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "285",
-        "end": "285",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.17,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021852C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "284",
-        "end": "284",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.35,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021855C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "276",
-        "end": "276",
-        "wildType": "T",
-        "frequency": 0.00159744,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.53,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021879T>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "269",
-        "end": "269",
-        "wildType": "T",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.07,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021899G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "256",
-        "end": "256",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.02,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021939C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "255",
-        "end": "255",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021942C>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "254",
-        "end": "254",
-        "wildType": "V",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.742,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.0975,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021945C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "N",
-        "begin": "248",
-        "end": "248",
-        "wildType": "D",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.12,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26021963C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "G",
-        "begin": "23",
-        "end": "23",
-        "wildType": "D",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.06,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26112136T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "227",
-        "end": "227",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.15,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26022026C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "A",
-        "begin": "225",
-        "end": "225",
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.418,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.405,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26022031A>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "206",
-        "end": "206",
-        "wildType": "S",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.192,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.06,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051045G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "A",
-        "begin": "196",
-        "end": "196",
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.91,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051075A>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "191",
-        "end": "191",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.225,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051091C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "D",
-        "begin": "191",
-        "end": "191",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.49,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051089T>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "M",
-        "begin": "185",
-        "end": "185",
-        "wildType": "V",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051109C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "L",
-        "begin": "184",
-        "end": "184",
-        "wildType": "F",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051110A>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Q",
-        "begin": "183",
-        "end": "183",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051115C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "178",
-        "end": "178",
-        "wildType": "K",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 1,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051129T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "I",
-        "begin": "170",
-        "end": "170",
-        "evidences": [
-          {
-            "code": "ECO:0000269",
-            "sources": [
-              {
-                "name": "PubMed",
-                "id": "17047026",
-                "url": "http://www.ncbi.nlm.nih.gov/pubmed/17047026"
-              }
-            ]
-          }
-        ],
-        "xrefs": [
-              {
-                "name": "dbSNP",
-                "id": "rs372642708",
-                "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs372642708"
-              }
-        ],
-        "wildType": "M",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051152C>T",
-        "association": [
-          {
-            "name": "Spermatogenic failure 11 (SPGF11)",
-            "description": "results in impaired self-association. Ftid: VAR_000016",
-            "moreInfo": [
-              {
-                "name": "OMIM",
-                "id": "615081",
-                "url": "http://www.omim.org/entry/615081"
-              }
-            ]
-          }
-        ],
-        "clinicalSignificances": "disease",
-        "disease": true,
-        "sourceType": "Mixed"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "Y",
-        "begin": "158",
-        "end": "158",
-        "wildType": "C",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0.27850002,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26051189C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "T",
-        "begin": "154",
-        "end": "154",
-        "wildType": "A",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0.015,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26053244C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "STOP_GAINED",
-          "label": "stop gained"
-        },
-        "mutation": "*",
-        "begin": "150",
-        "end": "150",
-        "wildType": "W",
-        "frequency": 0,
-        "polyphenScore": 0,
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26053254C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "K",
-        "begin": "145",
-        "end": "145",
-        "wildType": "E",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.095,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26053271C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "R",
-        "begin": "134",
-        "end": "134",
-        "wildType": "K",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.51,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26053303T>C",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "V",
-        "begin": "126",
-        "end": "126",
-        "wildType": "A",
-        "frequency": 0,
-        "polyphenPrediction": "benign",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.58000004,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26053327G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "S",
-        "begin": "114",
-        "end": "114",
-        "wildType": "P",
-        "frequency": 0,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 1,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26089958G>A",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "D",
-        "begin": "101",
-        "end": "101",
-        "wildType": "G",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "tolerated",
-        "siftScore": 0.24,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26089996C>T",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      },
-      {
-        "type": {
-          "name": "MISSENSE",
-          "label": "missense"
-        },
-        "mutation": "P",
-        "begin": "100",
-        "end": "100",
-        "wildType": "R",
-        "frequency": 0.000199681,
-        "polyphenPrediction": "unknown",
-        "polyphenScore": 0,
-        "siftPrediction": "deleterious",
-        "siftScore": 0,
-        "somaticStatus": 0,
-        "cytogeneticBand": "21q21.3",
-        "genomicLocation": "21:g.26089999C>G",
-        "disease": false,
-        "sourceType": "large_scale_study"
-      }
-    ]
-  }
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12665801",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12665801",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12665801"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "2900137",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/2900137",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/2900137"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "3597385",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/3597385",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/3597385"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000088",
+      "description": "Amyloid beta A4 protein",
+      "begin": "18",
+      "end": "770"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000089",
+      "description": "Soluble APP-alpha",
+      "begin": "18",
+      "end": "687"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000090",
+      "description": "Soluble APP-beta",
+      "begin": "18",
+      "end": "671"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000381966",
+      "description": "N-APP",
+      "begin": "18",
+      "end": "286"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000091",
+      "description": "C99",
+      "begin": "672",
+      "end": "770"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000092",
+      "description": "Beta-amyloid protein 42",
+      "begin": "672",
+      "end": "713"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000093",
+      "description": "Beta-amyloid protein 40",
+      "begin": "672",
+      "end": "711"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000094",
+      "description": "C83",
+      "begin": "688",
+      "end": "770"
+
+    },
+    {
+
+      "type": "PEPTIDE",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000095",
+      "description": "P3(42)",
+      "begin": "688",
+      "end": "713"
+
+    },
+    {
+
+      "type": "PEPTIDE",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000096",
+      "description": "P3(40)",
+      "begin": "688",
+      "end": "711"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000384574",
+      "description": "C80",
+      "begin": "691",
+      "end": "770"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000097",
+      "description": "Gamma-secretase C-terminal fragment 59",
+      "begin": "712",
+      "end": "770"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000098",
+      "description": "Gamma-secretase C-terminal fragment 57",
+      "begin": "714",
+      "end": "770"
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000099",
+      "description": "Gamma-secretase C-terminal fragment 50",
+      "begin": "721",
+      "end": "770",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000250"
+        }
+      ]
+
+    },
+    {
+
+      "type": "CHAIN",
+      "category": "MOLECULE_PROCESSING",
+      "ftId": "PRO_0000000100",
+      "description": "C31",
+      "begin": "740",
+      "end": "770"
+
+    },
+    {
+
+      "type": "TOPO_DOM",
+      "category": "TOPOLOGY",
+      "description": "Extracellular",
+      "begin": "18",
+      "end": "699",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000255"
+        }
+      ]
+
+    },
+    {
+
+      "type": "TRANSMEM",
+      "category": "TOPOLOGY",
+      "description": "Helical",
+      "begin": "700",
+      "end": "723",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000255"
+        }
+      ]
+
+    },
+    {
+
+      "type": "TOPO_DOM",
+      "category": "TOPOLOGY",
+      "description": "Cytoplasmic",
+      "begin": "724",
+      "end": "770",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000255"
+        }
+      ]
+
+    },
+    {
+
+      "type": "DOMAIN",
+      "category": "DOMAINS_AND_SITES",
+      "description": "BPTI/Kunitz inhibitor",
+      "begin": "291",
+      "end": "341",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000255",
+          "source":
+
+          {
+            "name": "PROSITE-ProRule",
+            "id": "PRU00031",
+            "url": "http://prosite.expasy.org/unirule/PRU00031"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "REGION",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Heparin-binding",
+      "begin": "96",
+      "end": "110"
+
+    },
+    {
+
+      "type": "REGION",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Zinc-binding",
+      "begin": "181",
+      "end": "188"
+
+    },
+    {
+
+      "type": "REGION",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Heparin-binding",
+      "begin": "391",
+      "end": "423"
+
+    },
+    {
+
+      "type": "REGION",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Heparin-binding",
+      "begin": "491",
+      "end": "522"
+
+    },
+    {
+
+      "type": "REGION",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Collagen-binding",
+      "begin": "523",
+      "end": "540"
+
+    },
+    {
+
+      "type": "REGION",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Interaction with G(o)-alpha",
+      "begin": "732",
+      "end": "751"
+
+    },
+    {
+
+      "type": "MOTIF",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Basolateral sorting signal",
+      "begin": "724",
+      "end": "734"
+
+    },
+    {
+
+      "type": "MOTIF",
+      "category": "DOMAINS_AND_SITES",
+      "description": "NPXY motif; contains endocytosis signal",
+      "begin": "759",
+      "end": "762"
+
+    },
+    {
+
+      "type": "COMPBIAS",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "Asp/Glu-rich (acidic)",
+      "begin": "230",
+      "end": "260"
+
+    },
+    {
+
+      "type": "COMPBIAS",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "Poly-Thr",
+      "begin": "274",
+      "end": "280"
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper 1",
+      "begin": "147",
+      "end": "147"
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper 1",
+      "begin": "151",
+      "end": "151"
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper 1",
+      "begin": "168",
+      "end": "168"
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper or zinc 2",
+      "begin": "677",
+      "end": "677"
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper or zinc 2",
+      "begin": "681",
+      "end": "681",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper or zinc 2",
+      "begin": "684",
+      "end": "684"
+
+    },
+    {
+
+      "type": "METAL",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Copper or zinc 2",
+      "begin": "685",
+      "end": "685"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Required for Cu(2+) reduction",
+      "begin": "144",
+      "end": "144"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Reactive bond",
+      "begin": "301",
+      "end": "302"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by beta-secretase",
+      "begin": "671",
+      "end": "672"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by caspase-6; when associated with variant 670-N-L-671",
+      "begin": "672",
+      "end": "673"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by alpha-secretase",
+      "begin": "687",
+      "end": "688"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by theta-secretase",
+      "begin": "690",
+      "end": "691"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Implicated in free radical propagation",
+      "begin": "704",
+      "end": "704",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000250"
+        }
+      ]
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Susceptible to oxidation",
+      "begin": "706",
+      "end": "706",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10535332",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10535332",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10535332"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by gamma-secretase; site 1",
+      "begin": "711",
+      "end": "712"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by gamma-secretase; site 2",
+      "begin": "713",
+      "end": "714"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by gamma-secretase; site 3",
+      "begin": "720",
+      "end": "721"
+
+    },
+    {
+
+      "type": "SITE",
+      "category": "DOMAINS_AND_SITES",
+      "description": "Cleavage; by caspase-6, caspase-8 or caspase-9",
+      "begin": "739",
+      "end": "740"
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphoserine; by CK2",
+      "begin": "198",
+      "end": "198",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8999878",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8999878"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphoserine; by CK1",
+      "begin": "206",
+      "end": "206",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8999878",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8999878"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphoserine; by FAM20C",
+      "begin": "441",
+      "end": "441",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "26091039",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/26091039",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/26091039"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphotyrosine",
+      "begin": "497",
+      "end": "497",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "26091039",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/26091039",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/26091039"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphothreonine",
+      "begin": "729",
+      "end": "729",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000250",
+          "source":
+
+          {
+            "name": "UniProtKB",
+            "id": "P08592",
+            "url": "http://www.uniprot.org/uniprot/P08592"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphoserine; by APP-kinase I",
+      "begin": "730",
+      "end": "730",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000250"
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphothreonine; by CDK5 and MAPK10",
+      "begin": "743",
+      "end": "743",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24275569",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24275569",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24275569"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8131745",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8131745",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8131745"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MOD_RES",
+      "category": "PTM",
+      "description": "Phosphotyrosine",
+      "begin": "757",
+      "end": "757",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11877420",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11877420"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "542",
+      "end": "542",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16335952",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16335952",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16335952"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "571",
+      "end": "571",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "614",
+      "end": "614",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22576872",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22576872"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "623",
+      "end": "623",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22576872",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22576872"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "628",
+      "end": "628",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22576872",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22576872"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "633",
+      "end": "633",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21712440",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21712440"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "651",
+      "end": "651",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21712440",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21712440"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "652",
+      "end": "652",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21712440",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21712440"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "in L-APP isoforms",
+      "begin": "656",
+      "end": "656",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21712440",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21712440"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "659",
+      "end": "659"
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "663",
+      "end": "663",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000305",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21712440",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21712440"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "667",
+      "end": "667",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000305",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21712440",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21712440",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21712440"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "679",
+      "end": "679",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22576872",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22576872"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CARBOHYD",
+      "category": "PTM",
+      "ftId": "",
+      "description": "",
+      "begin": "697",
+      "end": "697",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22576872",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22576872",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22576872"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "38",
+      "end": "62"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "73",
+      "end": "117"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "98",
+      "end": "105"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "133",
+      "end": "187"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "144",
+      "end": "174"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "158",
+      "end": "186"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "291",
+      "end": "341"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "300",
+      "end": "324"
+
+    },
+    {
+
+      "type": "DISULFID",
+      "category": "PTM",
+      "description": "",
+      "begin": "316",
+      "end": "337"
+
+    },
+    {
+
+      "type": "CROSSLNK",
+      "category": "PTM",
+      "description": "Glycyl lysine isopeptide (Lys-Gly) (interchain with G-Cter in ubiquitin)",
+      "begin": "763",
+      "end": "763",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000250",
+          "source":
+
+          {
+            "name": "UniProtKB",
+            "id": "P08592",
+            "url": "http://www.uniprot.org/uniprot/P08592"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_045446",
+      "begin": "1",
+      "end": "19",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "14702039",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/14702039",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/14702039"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_009116",
+      "begin": "19",
+      "end": "74",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12859342",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12859342",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12859342"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_009117",
+      "begin": "289",
+      "end": "363",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12859342",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12859342",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12859342"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000002",
+      "begin": "289",
+      "end": "289",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "2881207",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/2881207",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/2881207"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000004",
+      "begin": "290",
+      "end": "364",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "2881207",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/2881207",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/2881207"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000003",
+      "begin": "290",
+      "end": "345",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000005",
+      "begin": "290",
+      "end": "305",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15489334",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15489334",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15489334"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000006",
+      "begin": "306",
+      "end": "770",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15489334",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15489334",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15489334"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_045447",
+      "begin": "345",
+      "end": "364",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "14702039",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/14702039",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/14702039"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000007",
+      "begin": "345",
+      "end": "345",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15489334",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15489334",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15489334"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1587857",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1587857",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1587857"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "2893289",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/2893289",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/2893289"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000008",
+      "begin": "346",
+      "end": "364",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15489334",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15489334",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15489334"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1587857",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1587857",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1587857"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "2893289",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/2893289",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/2893289"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_009118",
+      "begin": "364",
+      "end": "364",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12859342",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12859342",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12859342"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VAR_SEQ",
+      "category": "VARIANTS",
+      "ftId": "VSP_000009",
+      "begin": "637",
+      "end": "654",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000303",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1587857",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1587857",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1587857"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_022315",
+      "description": "in dbSNP:rs45588932",
+      "alternativeSequence": "K",
+      "begin": "501",
+      "end": "501",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "Citation",
+            "id": "Ref.10",
+            "url": "http://www.uniprot.org/uniprot/P05067#ref10"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_010107",
+      "description": "in a patient with late onset Alzheimer disease",
+      "alternativeSequence": "D",
+      "begin": "665",
+      "end": "665",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8154870",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8154870",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8154870"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000015",
+      "description": "in AD1",
+      "alternativeSequence": "NL",
+      "begin": "670",
+      "end": "671"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_044424",
+      "description": "in AD1",
+      "alternativeSequence": "N",
+      "begin": "678",
+      "end": "678",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15201367",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15201367",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15201367"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000016",
+      "description": "in AD1; Flemish mutation; increases the solubility of processed beta-amyloid peptides and increases the stability of peptide oligomers",
+      "alternativeSequence": "G",
+      "begin": "692",
+      "end": "692",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11311152",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11311152",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11311152"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1303239",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1303239",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1303239"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9754958",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9754958",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9754958"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_014215",
+      "description": "in AD1",
+      "alternativeSequence": "G",
+      "begin": "693",
+      "end": "693",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11528419",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11528419",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11528419"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1415269",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1415269",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1415269"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_014216",
+      "description": "in CAA-APP; Italian type",
+      "alternativeSequence": "K",
+      "begin": "693",
+      "end": "693",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "20697050",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/20697050",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/20697050"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000017",
+      "description": "in CAA-APP; Dutch type",
+      "alternativeSequence": "Q",
+      "begin": "693",
+      "end": "693",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "2111584",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/2111584",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/2111584"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_014217",
+      "description": "in CAA-APP; Iowa type",
+      "alternativeSequence": "N",
+      "begin": "694",
+      "end": "694",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11409420",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11409420",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11409420"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12654973",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12654973",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12654973"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_032276",
+      "description": "in CAA-APP; Italian type",
+      "alternativeSequence": "V",
+      "begin": "705",
+      "end": "705",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16178030",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16178030",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16178030"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000019",
+      "description": "in AD1",
+      "alternativeSequence": "T",
+      "begin": "713",
+      "end": "713",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1303275",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1303275",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1303275"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15365148",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15365148",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15365148"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000018",
+      "description": "in one chronic schizophrenia patient; unknown pathological significance; dbSNP:rs1800557",
+      "alternativeSequence": "V",
+      "begin": "713",
+      "end": "713",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1307241",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1307241",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1307241"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_032277",
+      "description": "in AD1",
+      "alternativeSequence": "A",
+      "begin": "714",
+      "end": "714",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12034808",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12034808",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12034808"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_014218",
+      "description": "in AD1; increased beta-APP42/ beta-APP40 ratio",
+      "alternativeSequence": "I",
+      "begin": "714",
+      "end": "714",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11063718",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11063718"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15668448",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15668448",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15668448"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_010108",
+      "description": "in AD1; decreased beta-APP40/ total APP-beta",
+      "alternativeSequence": "M",
+      "begin": "715",
+      "end": "715",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10097173",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10097173",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10097173"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000020",
+      "description": "in AD1",
+      "alternativeSequence": "V",
+      "begin": "716",
+      "end": "716",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9328472",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9328472",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9328472"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000023",
+      "description": "in AD1",
+      "alternativeSequence": "F",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1925564",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1925564",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1925564"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8267572",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8267572",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8267572"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8290042",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8290042",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8290042"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8476439",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8476439"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000022",
+      "description": "in AD1",
+      "alternativeSequence": "G",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1944558",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1944558",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1944558"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8476439",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8476439"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_000021",
+      "description": "in AD1",
+      "alternativeSequence": "I",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10631141",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10631141",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10631141"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1671712",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1671712",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1671712"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1678058",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1678058",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1678058"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "1908231",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/1908231",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/1908231"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8267572",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8267572",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8267572"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8476439",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8476439",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8476439"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8577393",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8577393",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8577393"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_014219",
+      "description": "in AD1",
+      "alternativeSequence": "L",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10867787",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10867787",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10867787"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "VARIANT",
+      "category": "VARIANTS",
+      "ftId": "VAR_010109",
+      "description": "in AD1",
+      "alternativeSequence": "P",
+      "begin": "723",
+      "end": "723",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10665499",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10665499",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10665499"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced heparin-binding",
+      "alternativeSequence": "NQGG",
+      "begin": "99",
+      "end": "102",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8158260",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8158260",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8158260"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Binds copper. Forms dimer",
+      "alternativeSequence": "N",
+      "begin": "137",
+      "end": "137",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Binds copper. Forms dimer",
+      "alternativeSequence": "T",
+      "begin": "141",
+      "end": "141",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Binds copper. No dimer formation. No copper reducing activity",
+      "alternativeSequence": "S",
+      "begin": "144",
+      "end": "144",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10461923",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10461923",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10461923"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "50% decrease in copper reducing activity",
+      "alternativeSequence": "ALA",
+      "begin": "147",
+      "end": "149",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10461923",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10461923",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10461923"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Some decrease in copper reducing activity",
+      "alternativeSequence": "A",
+      "begin": "147",
+      "end": "147",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11784781",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11784781"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Binds copper. Forms dimer",
+      "alternativeSequence": "N",
+      "begin": "147",
+      "end": "147",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11784781",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11784781"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Greatly reduced copper-mediated low-density lipoprotein oxidation",
+      "alternativeSequence": "Y",
+      "begin": "147",
+      "end": "147",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11784781",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11784781"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Greatly reduced copper-mediated low-density lipoprotein oxidation",
+      "alternativeSequence": "K",
+      "begin": "151",
+      "end": "151",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11784781",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11784781"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Binds copper. Forms dimer",
+      "alternativeSequence": "N",
+      "begin": "151",
+      "end": "151",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11784781",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11784781",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11784781"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7913895",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7913895",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7913895"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Greatly reduced casein kinase phosphorylation",
+      "alternativeSequence": "A",
+      "begin": "198",
+      "end": "198",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10806211",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10806211",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10806211"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8999878",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8999878"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced casein kinase phosphorylation",
+      "alternativeSequence": "A",
+      "begin": "206",
+      "end": "206",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10806211",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10806211",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10806211"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8999878",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8999878",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8999878"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced affinity for heparin; when associated with A-503",
+      "alternativeSequence": "A",
+      "begin": "499",
+      "end": "499",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15304215",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15304215",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15304215"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced affinity for heparin; when associated with A-499",
+      "alternativeSequence": "A",
+      "begin": "503",
+      "end": "503",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15304215",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15304215",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15304215"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Abolishes chondroitin sulfate binding in L-APP733 isoform",
+      "alternativeSequence": "A",
+      "begin": "656",
+      "end": "656",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7737970",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7737970",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7737970"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "60-70% zinc-induced beta-APP (28) peptide aggregation",
+      "alternativeSequence": "G",
+      "begin": "676",
+      "end": "676",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10413512",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10413512",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10413512"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "60-70% zinc-induced beta-APP (28) peptide aggregation",
+      "alternativeSequence": "F",
+      "begin": "681",
+      "end": "681",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10413512",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10413512",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10413512"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Only 23% zinc-induced beta-APP (28) peptide aggregation",
+      "alternativeSequence": "R",
+      "begin": "684",
+      "end": "684",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10413512",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10413512",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10413512"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced protein oxidation. No hippocampal neuron toxicity",
+      "alternativeSequence": "V",
+      "begin": "704",
+      "end": "704"
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced lipid peroxidation inhibition",
+      "alternativeSequence": "L",
+      "begin": "706",
+      "end": "706",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10535332",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10535332",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10535332"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9168929",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9168929",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9168929"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "No free radical production. No hippocampal neuron toxicity",
+      "alternativeSequence": "V",
+      "begin": "706",
+      "end": "706",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10535332",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10535332",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10535332"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9168929",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9168929",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9168929"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Unchanged beta-APP42/total APP-beta ratio",
+      "alternativeSequence": "C,S",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11063718",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11063718"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8886002",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8886002"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Increased beta-APP42/beta-APP40 ratio",
+      "alternativeSequence": "F,G,I",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11063718",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11063718"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8886002",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8886002"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Decreased beta-APP42/total APP-beta ratio",
+      "alternativeSequence": "K",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11063718",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11063718"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8886002",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8886002"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Increased beta-APP42/beta-APP40 ratio. No change in apoptosis after caspase cleavage",
+      "alternativeSequence": "M",
+      "begin": "717",
+      "end": "717",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11063718",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11063718",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11063718"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8886002",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8886002",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8886002"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "No effect on APBA1 nor APBB1 binding. Greatly reduces the binding to APPBP2. APP internalization unchanged. No change in beta-APP42 secretion",
+      "alternativeSequence": "A",
+      "begin": "728",
+      "end": "728",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8887653",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8887653"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9843960",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9843960",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9843960"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "No cleavage by caspases during apoptosis",
+      "alternativeSequence": "A",
+      "begin": "739",
+      "end": "739",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10319819",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10319819",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10319819"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10742146",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10742146",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10742146"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12214090",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12214090",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12214090"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "No effect on FADD-induced apoptosis",
+      "alternativeSequence": "N",
+      "begin": "739",
+      "end": "739",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10319819",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10319819",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10319819"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10742146",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10742146",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10742146"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12214090",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12214090",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12214090"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Greatly reduces the binding to SHC1 and APBB family members; no effect on NGF-stimulated neurite extension",
+      "alternativeSequence": "A",
+      "begin": "743",
+      "end": "743",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10341243",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10341243",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10341243"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11146006",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11146006",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11146006"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11517218",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11517218",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11517218"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11877420",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11877420"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Reduced NGF-stimulated neurite extension. No effect on APP maturation",
+      "alternativeSequence": "E",
+      "begin": "743",
+      "end": "743",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10341243",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10341243",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10341243"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11146006",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11146006",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11146006"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11517218",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11517218",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11517218"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11877420",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11877420"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "APP internalization unchanged. No change in beta-APP42 secretion",
+      "alternativeSequence": "A",
+      "begin": "756",
+      "end": "756",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Little APP internalization. Reduced beta-APP42 secretion",
+      "alternativeSequence": "A",
+      "begin": "757",
+      "end": "757",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11724784",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11724784",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11724784"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11877420",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11877420"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8887653",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8887653"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Loss of binding to MAPK8IP1, APBA1, APBB1, APPBP2 and SHC1",
+      "alternativeSequence": "G",
+      "begin": "757",
+      "end": "757",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11724784",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11724784",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11724784"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11877420",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11877420",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11877420"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8887653",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8887653"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "No binding to APBA1, no effect on APBB1 binding. Little APP internalization. Reduced beta-APP42 secretion",
+      "alternativeSequence": "A",
+      "begin": "759",
+      "end": "759",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8887653",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8887653"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Little APP internalization. Reduced beta-APP42 secretion",
+      "alternativeSequence": "A",
+      "begin": "760",
+      "end": "760",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "MUTAGEN",
+      "category": "MUTAGENESIS",
+      "description": "Loss of binding to APBA1 and APBB1. APP internalization unchanged. No change in beta-APP42 secretion",
+      "alternativeSequence": "A",
+      "begin": "762",
+      "end": "762",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10383380",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10383380",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10383380"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8887653",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8887653",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8887653"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "CONFLICT",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "in Ref. 3; CAA31830",
+      "alternativeSequence": "VW",
+      "begin": "15",
+      "end": "16",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "CONFLICT",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "in Ref. 36; AAA51722",
+      "alternativeSequence": "E",
+      "begin": "647",
+      "end": "647",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "CONFLICT",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "in Ref. 23; AAB26263/AAB26264",
+      "alternativeSequence": "",
+      "begin": "724",
+      "end": "724",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "CONFLICT",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "in Ref. 23; AAB26263/AAB26264/ AAB26265",
+      "alternativeSequence": "N",
+      "begin": "731",
+      "end": "731",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "CONFLICT",
+      "category": "SEQUENCE_INFORMATON",
+      "description": "in Ref. 31; AAA35540",
+      "alternativeSequence": "S",
+      "begin": "757",
+      "end": "757",
+      "evidences":
+
+      [
+
+        {
+          "code": "ECO:0000305"
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "26",
+      "end": "28",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "33",
+      "end": "35",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "43",
+      "end": "45",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "TURN",
+      "category": "STRUCTURAL",
+      "begin": "47",
+      "end": "49",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "52",
+      "end": "54",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "56",
+      "end": "58",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PWQ",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PWQ"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "66",
+      "end": "76",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "82",
+      "end": "87",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "92",
+      "end": "94",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "97",
+      "end": "99",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "TURN",
+      "category": "STRUCTURAL",
+      "begin": "100",
+      "end": "102",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "103",
+      "end": "106",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "110",
+      "end": "112",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "115",
+      "end": "119",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4PQD",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4PQD"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "134",
+      "end": "139",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2FMA",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2FMA"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "147",
+      "end": "160",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2FMA",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2FMA"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "163",
+      "end": "174",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2FMA",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2FMA"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "TURN",
+      "category": "STRUCTURAL",
+      "begin": "175",
+      "end": "177",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2FMA",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2FMA"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "178",
+      "end": "188",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2FMA",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2FMA"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "288",
+      "end": "292",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "299",
+      "end": "301",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "304",
+      "end": "310",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "TURN",
+      "category": "STRUCTURAL",
+      "begin": "311",
+      "end": "314",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "315",
+      "end": "321",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "323",
+      "end": "325",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "331",
+      "end": "333",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "334",
+      "end": "341",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1AAP",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1AAP"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "374",
+      "end": "380",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3NYL",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3NYL"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "389",
+      "end": "418",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "421",
+      "end": "423",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "425",
+      "end": "480",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "482",
+      "end": "484",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3NYJ",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3NYJ"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "487",
+      "end": "518",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "520",
+      "end": "546",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "547",
+      "end": "550",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "552",
+      "end": "566",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3UMH",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3UMH"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "673",
+      "end": "675",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4OJF",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4OJF"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "676",
+      "end": "678",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2MVX",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2MVX"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "679",
+      "end": "682",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1BA6",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1BA6"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "683",
+      "end": "685",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1BA4",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1BA4"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "688",
+      "end": "691",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3OVJ",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3OVJ"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "692",
+      "end": "694",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4MVI",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4MVI"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "TURN",
+      "category": "STRUCTURAL",
+      "begin": "695",
+      "end": "698",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "4MVI",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/4MVI"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "702",
+      "end": "705",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2Y3J",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2Y3J"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "707",
+      "end": "712",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "2Y3K",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/2Y3K"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "HELIX",
+      "category": "STRUCTURAL",
+      "begin": "744",
+      "end": "754",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3DXE",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3DXE"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "755",
+      "end": "758",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "1X11",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/1X11"
+          }
+        }
+      ]
+
+    },
+    {
+
+      "type": "STRAND",
+      "category": "STRUCTURAL",
+      "begin": "763",
+      "end": "765",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000244",
+          "source":
+
+          {
+            "name": "PDB",
+            "id": "3L81",
+            "url": "http://www.ebi.ac.uk/pdbe-srv/view/entry/3L81"
+          }
+        }
+      ]
+    }
+  ]
+
 }

--- a/snippets/data/peptides.json
+++ b/snippets/data/peptides.json
@@ -1,0 +1,3203 @@
+{
+
+  "accession": "P05067",
+  "entryName": "A4_HUMAN",
+  "sequence": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGRLNMHMNVQNGKWDSDPSGTKTCIDTKEGILQYCQEVYPELQITNVVEANQPVTIQNWCKRGRKQCKTHPHFVIPYRCLVGEFVSDALLVPDKCKFLHQERMDVCETHLHWHTVAKETCSEKSTNLHDYGMLLPCGIDKFRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDKVVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATERTTSIATTTTTTTESVEEVVREVCSEQAETGPCRAMISRWYFDVTEGKCAPFFYGGCGGNRNNFDTEEYCMAVCGSAMSQSLLKTTQEPLARDPVKLPTTAASTPDAVDKYLETPGDENEHAHFQKAKERLEAKHRERMSQVMREWEEAERQAKNLPKADKKAVIQHFQEKVESLEQEAANERQQLVETHMARVEAMLNDRRRLALENYITALQAVPPRPRHVFNMLKKYVRAEQKDRQHTLKHFEHVRMVDPKKAAQIRSQVMTHLRVIYERMNQSLSLLYNVPAVAEEIQDEVDELLQKEQNYSDDVLANMISEPRISYGNDALMPSLTETKTTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADRGLTTRPGSGLTNIKTEEISEVKMDAEFRHDSGYEVHHQKLVFFAEDVGSNKGAIIGLMVGGVVIATVIVITLVMLKKKQYTSIHHGVVEVDAAVTPEERHLSKMQQNGYENPTYKFFEQMQN",
+  "sequenceChecksum": "A12EE761403740F5",
+  "taxid" : 9606,
+  "features":
+
+  [
+
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "764",
+      "end": "770",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "FFEQMQN",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "752",
+      "end": "763",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "MQQNGYENPTYK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "747",
+      "end": "766",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "RHLSKMQQNGYENPTYKFFE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "746",
+      "end": "766",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "ERHLSKMQQNGYENPTYKFFE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "727",
+      "end": "751",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "QYTSIHHGVVEVDAAVTPEERHLSK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "727",
+      "end": "747",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "QYTSIHHGVVEVDAAVTPEER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "726",
+      "end": "747",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "KQYTSIHHGVVEVDAAVTPEER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "688",
+      "end": "699",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LVFFAEDVGSNK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "677",
+      "end": "687",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "HDSGYEVHHQK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "675",
+      "end": "682",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "FRHDSGYE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "671",
+      "end": "687",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "MDAEFRHDSGYEVHHQK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "67",
+      "end": "99",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "EGILQYCQEVYPELQITNVVEANQPVTIQNWCK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "67",
+      "end": "100",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "EGILQYCQEVYPELQITNVVEANQPVTIQNWCKR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "663",
+      "end": "676",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TEEISEVKMDAEFR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "663",
+      "end": "670",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TEEISEVK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "654",
+      "end": "662",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "PGSGLTNIK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "649",
+      "end": "670",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "GLTTRPGSGLTNIKTEEISEVK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "649",
+      "end": "662",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "GLTTRPGSGLTNIK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "627",
+      "end": "646",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DSVPANTENEVEPVDARPAA",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "618",
+      "end": "636",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LQPWHSFGADSVPANTENE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "617",
+      "end": "646",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DLQPWHSFGADSVPANTENEVEPVDARPAA",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "616",
+      "end": "626",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DDLQPWHSFGA",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "602",
+      "end": "648",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDARPAADR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "602",
+      "end": "643",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TTVELLPVNGEFSLDDLQPWHSFGADSVPANTENEVEPVDAR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "586",
+      "end": "601",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "ISYGNDALMPSLTETK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "574",
+      "end": "590",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DDVLANMISEPRISYGN",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "569",
+      "end": "585",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "EQNYSDDVLANMISEPR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "563",
+      "end": "573",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DELLQKEQNYS",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "560",
+      "end": "573",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DEVDELLQKEQNYS",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "541",
+      "end": "568",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "MNQSLSLLYNVPAVAEEIQDEVDELLQK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "528",
+      "end": "535",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "SQVMTHLR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "52",
+      "end": "60",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "WDSDPSGTK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "489",
+      "end": "496",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "HVFNMLKK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "489",
+      "end": "495",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "HVFNMLK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "471",
+      "end": "488",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LALENYITALQAVPPRPR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "471",
+      "end": "486",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LALENYITALQAVPPR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "470",
+      "end": "488",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "RLALENYITALQAVPPRPR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "461",
+      "end": "469",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "VEAMLNDRR",
+      "unique": false
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "461",
+      "end": "468",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "VEAMLNDR",
+      "unique": false
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "451",
+      "end": "460",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "QQLVETHMAR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "439",
+      "end": "460",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "VESLEQEAANERQQLVETHMAR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "439",
+      "end": "450",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "VESLEQEAANER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "436",
+      "end": "453",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "QEKVESLEQEAANERQQL",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "430",
+      "end": "460",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "AVIQHFQEKVESLEQEAANERQQLVETHMAR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "430",
+      "end": "450",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "AVIQHFQEKVESLEQEAANER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "430",
+      "end": "438",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "AVIQHFQEK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "429",
+      "end": "438",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "KAVIQHFQEK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "412",
+      "end": "418",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "EWEEAER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "41",
+      "end": "60",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LNMHMNVQNGKWDSDPSGTK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "41",
+      "end": "51",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LNMHMNVQNGK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "406",
+      "end": "418",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "MSQVMREWEEAER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "379",
+      "end": "391",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LETPGDENEHAHF",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "378",
+      "end": "393",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "YLETPGDENEHAHFQK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "364",
+      "end": "377",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LPTTAASTPDAVDK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "360",
+      "end": "377",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "DPVKLPTTAASTPDAVDK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "352",
+      "end": "359",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TTQEPLAR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "329",
+      "end": "351",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "NNFDTEEYCMAVCGSAMSQSLLK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "322",
+      "end": "336",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "GGCGGNRNNFDTEEY",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "316",
+      "end": "328",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "CAPFFYGGCGGNR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "314",
+      "end": "335",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "GKCAPFFYGGCGGNRNNFDTEE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "308",
+      "end": "319",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "YFDVTEGKCAPF",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "307",
+      "end": "315",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "WYFDVTEGK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "289",
+      "end": "306",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "EVCSEQAETGPCRAMISR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "289",
+      "end": "301",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "EVCSEQAETGPCR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "269",
+      "end": "301",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TTSIATTTTTTTESVEEVVREVCSEQAETGPCR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "269",
+      "end": "288",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "TTSIATTTTTTTESVEEVVR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "268",
+      "end": "281",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "RTTSIATTTTTTTE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "225",
+      "end": "268",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "VVEVAEEEEVAEVEEEEADDDEDDEDGDEVEEEAEEPYEEATER",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "181",
+      "end": "224",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "GVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "179",
+      "end": "224",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "FRGVEFVCCPLAEESDNVDSADAEEDDSDVWWGGADTDYADGSEDK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "17",
+      "end": "40",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "ALEVPTDGNAGLLAEPQIAMFCGR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "169",
+      "end": "179",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "GMLLPCGIDKF",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "168",
+      "end": "183",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "YGMLLPCGIDKFRGVE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "162",
+      "end": "180",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "STNLHDYGMLLPCGIDKFR",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "162",
+      "end": "178",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "STNLHDYGMLLPCGIDK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "161",
+      "end": "183",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "KSTNLHDYGMLLPCGIDKFRGVE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "151",
+      "end": "168",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "HTVAKETCSEKSTNLHDY",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "146",
+      "end": "156",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "THLHWHTVAKE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "141",
+      "end": "155",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "MDVCETHLHWHTVAK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "137",
+      "end": "150",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "HQERMDVCETHLHW",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "136",
+      "end": "150",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "LHQERMDVCETHLHW",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "126",
+      "end": "139",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "ALLVPDKCKFLHQE",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "123",
+      "end": "135",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "VSDALLVPDKCKF",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "117",
+      "end": "134",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "CLVGEFVSDALLVPDKCK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "117",
+      "end": "132",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "CLVGEFVSDALLVPDK",
+      "unique": true
+
+    },
+    {
+
+      "type": "PROTEOMICS",
+      "begin": "107",
+      "end": "116",
+      "xrefs":
+
+      [
+
+        {
+          "name": "Proteomes",
+          "id": "UP000005640"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "PeptideAtlas",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "MaxQB",
+            "id": "P05067"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000213",
+          "source":
+
+          {
+            "name": "EPD",
+            "id": "P05067"
+          }
+        }
+      ],
+      "peptide": "THPHFVIPYR",
+      "unique": true
+    }
+  ]
+
+}

--- a/snippets/data/variant.json
+++ b/snippets/data/variant.json
@@ -1,0 +1,17623 @@
+{
+
+  "accession": "P22607",
+  "entryName": "FGFR3_HUMAN",
+  "sequence": "MGAPACALALCVAVAIVAGASSESLGTEQRVVGRAAEVPGPEPGQQEQLVFGSGDAVELSCPPPGGGPMGPTVWVKDGTGLVPSERVLVGPQRLQVLNASHEDSGAYSCRQRLTQRVLCHFSVRVTDAPSSGDDEDGEDEAEDTGVDTGAPYWTRPERMDKKLLAVPAANTVRFRCPAAGNPTPSISWLKNGREFRGEHRIGGIKLRHQQWSLVMESVVPSDRGNYTCVVENKFGSIRQTYTLDVLERSPHRPILQAGLPANQTAVLGSDVEFHCKVYSDAQPHIQWLKHVEVNGSKVGPDGTPYVTVLKTAGANTTDKELEVLSLHNVTFEDAGEYTCLAGNSIGFSHHSAWLVVLPAEEELVEADEAGSVYAGILSYGVGFFLFILVVAAVTLCRLRSPPKKGLGSPTVHKISRFPLKRQVSLESNASMSSNTPLVRIARLSSGEGPTLANVSELELPADPKWELSRARLTLGKPLGEGCFGQVVMAEAIGIDKDRAAKPVTVAVKMLKDDATDKDLSDLVSEMEMMKMIGKHKNIINLLGACTQGGPLYVLVEYAAKGNLREFLRARRPPGLDYSFDTCKPPEEQLTFKDLVSCAYQVARGMEYLASQKCIHRDLAARNVLVTEDNVMKIADFGLARDVHNLDYYKKTTNGRLPVKWMAPEALFDRVYTHQSDVWSFGVLLWEIFTLGGSPYPGIPVEELFKLLKEGHRMDKPANCTHDLYMIMRECWHAAPSQRPTFKQLVEDLDRVLTVTSTDEYLDLSAPFEQYSPGGQDTPSSSSSGDDSVFAHDLLPPAPPSSGGSRT",
+  "sequenceChecksum": "BC5EA75EA46F447E",
+  "taxid" : 9606,
+  "features":
+
+  [
+
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "99",
+      "end": "99",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759815430",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759815430"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.314,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799439G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "W",
+      "begin": "93",
+      "end": "93",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs199968400",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199968400"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.19,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799421C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "93",
+      "end": "93",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771333357",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771333357"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.009,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.29,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799422G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "91",
+      "end": "91",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs144995231",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs144995231"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.02,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.3,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799416C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "L",
+      "begin": "84",
+      "end": "84",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913116",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913116"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.223,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799395C>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "W",
+      "begin": "807",
+      "end": "807",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913103",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913103"
+        }
+      ],
+      "wildType": "*",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807262A>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "R",
+      "begin": "807",
+      "end": "807",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913101",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913101"
+        }
+      ],
+      "wildType": "*",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807260T>A",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "807",
+      "end": "807",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs397515514",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs397515514"
+        }
+      ],
+      "wildType": "*",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807261G>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "G",
+      "begin": "807",
+      "end": "807",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913101",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913101"
+        }
+      ],
+      "wildType": "*",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807260T>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "C",
+      "begin": "807",
+      "end": "807",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913103",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913103"
+        }
+      ],
+      "wildType": "*",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807262A>C",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "M",
+      "begin": "806",
+      "end": "806",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs374547489",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs374547489"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428743",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428743"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807258C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "W",
+      "begin": "805",
+      "end": "805",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs369758941",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs369758941"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807254C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "805",
+      "end": "805",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs754152095",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs754152095"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807255G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "804",
+      "end": "804",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs751115449",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751115449"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.37,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807252C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): lung; in a lung adenocarcinoma sample; somatic mutation Ftid: VAR_042207",
+      "alternativeSequence": "S",
+      "begin": "79",
+      "end": "79",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM21226",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=21226"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:36",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=36"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17344846",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17344846",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17344846"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:34",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=34"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16140923",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16140923",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16140923"
+          }
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.009,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.79,
+      "somaticStatus": 1,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799379A>T",
+      "clinicalSignificances": "DISEASE",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "I",
+      "begin": "79",
+      "end": "79",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM1428664",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428664"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs778358980",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778358980"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.29500002,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799380C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "799",
+      "end": "799",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs150452037",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs150452037"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807237C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "796",
+      "end": "796",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs746909556",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs746909556"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.7,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807227C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "796",
+      "end": "796",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768644781",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768644781"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.5,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807228C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "796",
+      "end": "796",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768644781",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768644781"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.34,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807228C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "794",
+      "end": "794",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772193113",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772193113"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.2,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807221C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "792",
+      "end": "792",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs376043260",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs376043260"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.764,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807215G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "791",
+      "end": "791",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs576131994",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs576131994"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807214C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "788",
+      "end": "788",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs371433215",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371433215"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807203G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "786",
+      "end": "786",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs548817695",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs548817695"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807197G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "786",
+      "end": "786",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs548817695",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs548817695"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807197G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "785",
+      "end": "785",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768114770",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768114770"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807194G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "784",
+      "end": "784",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs531915147",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs531915147"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807191G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "781",
+      "end": "781",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764958279",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764958279"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.091,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807183G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "780",
+      "end": "780",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs140616343",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs140616343"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.832,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807180C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): lung",
+      "alternativeSequence": "R",
+      "begin": "779",
+      "end": "779",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1539829",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1539829"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:417",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=417"
+          }
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.86,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807178C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "777",
+      "end": "777",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs775451126",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs775451126"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.184,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807171C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "777",
+      "end": "777",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs775451126",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs775451126"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.501,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807171C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "776",
+      "end": "776",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771994959",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771994959"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807167G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "773",
+      "end": "773",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773197447",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773197447"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.254,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807159G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "773",
+      "end": "773",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773197447",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773197447"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.23,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807159G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "772",
+      "end": "772",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs756484252",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs756484252"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807156C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "772",
+      "end": "772",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs756484252",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs756484252"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807156C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "772",
+      "end": "772",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs748492376",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs748492376"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807155C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "771",
+      "end": "771",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs755526507",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs755526507"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807153C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "771",
+      "end": "771",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs755526507",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs755526507"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807153C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "770",
+      "end": "770",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764614806",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764614806"
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807150A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "*",
+      "begin": "770",
+      "end": "770",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs367757357",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs367757357"
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807151C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "768",
+      "end": "768",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs560280646",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs560280646"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807143G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "766",
+      "end": "766",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs763774428",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs763774428"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.792,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807138C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "765",
+      "end": "765",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs140211846",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs140211846"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807135C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "764",
+      "end": "764",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759398915",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759398915"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.619,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807132C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "763",
+      "end": "763",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs774517056",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs774517056"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.195,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1807128C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "758",
+      "end": "758",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs56266857",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs56266857"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.116,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806932G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "758",
+      "end": "758",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs747369218",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs747369218"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.133,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806934C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "757",
+      "end": "757",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs748763892",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs748763892"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.885,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806930C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "755",
+      "end": "755",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs752294041",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs752294041"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806924C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "754",
+      "end": "754",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs373425119",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs373425119"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.041,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.55,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806920G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "750",
+      "end": "750",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762888506",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762888506"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.996,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806909G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): lung",
+      "alternativeSequence": "C",
+      "begin": "750",
+      "end": "750",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs750501941",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750501941"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM397264",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=397264"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:431",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=431"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22980975",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22980975",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22980975"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99875003,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806908C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "742",
+      "end": "742",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs777034307",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs777034307"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.629,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806884A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "741",
+      "end": "741",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768999235",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768999235"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806882T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "73",
+      "end": "73",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs753541863",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs753541863"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.012,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.42,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799361G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "737",
+      "end": "737",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs536212792",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs536212792"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.995,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806870A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "736",
+      "end": "736",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs148631462",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs148631462"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806867C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "734",
+      "end": "734",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs555257146",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs555257146"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.006,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806861C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "734",
+      "end": "734",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs188849608",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs188849608"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.023,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806860G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "728",
+      "end": "728",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs149924317",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs149924317"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806843G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_022171",
+      "alternativeSequence": "F",
+      "begin": "726",
+      "end": "726",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs17880763",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs17880763"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "id": "ref.4"
+          }
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.995,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806836A>T",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "725",
+      "end": "725",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs377402598",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs377402598"
+        }
+      ],
+      "wildType": "M",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.319,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806835G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "721",
+      "end": "721",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs371088132",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371088132"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.398,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.24,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806678C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "*",
+      "begin": "719",
+      "end": "719",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs745674688",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs745674688"
+        }
+      ],
+      "wildType": "C",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806672C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "718",
+      "end": "718",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs139773438",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs139773438"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.021,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806668A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "718",
+      "end": "718",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778358",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778358"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.491,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.04,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806667A>G",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "717",
+      "end": "717",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs749192018",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs749192018"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.588,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.1,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806665C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_022170",
+      "alternativeSequence": "T",
+      "begin": "717",
+      "end": "717",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs17882190",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs17882190"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "id": "ref.4"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.147,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806664G>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): lung",
+      "alternativeSequence": "M",
+      "begin": "715",
+      "end": "715",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM732992",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=732992"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:418",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=418"
+          }
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.97,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806659A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "712",
+      "end": "712",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs104886024",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs104886024"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806650G>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "710",
+      "end": "710",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs104886023",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs104886023"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806644G>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "709",
+      "end": "709",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs755495007",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs755495007"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806640G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "709",
+      "end": "709",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs755133781",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs755133781"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806641A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "705",
+      "end": "705",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs369813768",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs369813768"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.841,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806629A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "704",
+      "end": "704",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs376497115",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs376497115"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.914,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806627C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "69",
+      "end": "69",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs373818958",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs373818958"
+        }
+      ],
+      "wildType": "M",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.78,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799349A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): upper aerodigestive tract",
+      "alternativeSequence": "C",
+      "begin": "697",
+      "end": "697",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM24802",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=24802"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15880580",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15880580",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15880580"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806604G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "693",
+      "end": "693",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs760292339",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs760292339"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.884,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806593C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): thyroid",
+      "alternativeSequence": "M",
+      "begin": "689",
+      "end": "689",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1237785",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1237785"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:463",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=463"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23264394",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23264394",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23264394"
+          }
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.98,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806581C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "687",
+      "end": "687",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759229319",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759229319"
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.664,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806574A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): upper aerodigestive tract",
+      "alternativeSequence": "K",
+      "begin": "686",
+      "end": "686",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29445",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29445"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19327639",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19327639",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19327639"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806571G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "67",
+      "end": "67",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs369232922",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs369232922"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 7.98722E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.012,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.6,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799344G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "679",
+      "end": "679",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769602256",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769602256"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.783,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806550T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "I",
+      "begin": "677",
+      "end": "677",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM178247",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=178247"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806326G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "673",
+      "end": "673",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs747364567",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs747364567"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.991,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806314C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "673",
+      "end": "673",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs751098892",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751098892"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.987,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806316C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "66",
+      "end": "66",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759546081",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759546081"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.232,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.79,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799340G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "Q",
+      "begin": "669",
+      "end": "669",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs773089715",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773089715"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428734",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428734"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.86,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806303G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "665",
+      "end": "665",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764892330",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764892330"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.252,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806290G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "662",
+      "end": "662",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773652498",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773652498"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806281G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_022167",
+      "alternativeSequence": "R",
+      "begin": "65",
+      "end": "65",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs2305178",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs2305178"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "id": "ref.4"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.00259585,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.56,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799337G>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "S",
+      "begin": "653",
+      "end": "653",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428732",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428732"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806172A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "653",
+      "end": "653",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs150609697",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs150609697"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806173C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "H",
+      "begin": "653",
+      "end": "653",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29440",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29440"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806171A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "652",
+      "end": "652",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs753665954",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs753665954"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.996,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806169C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): central nervous system, urinary tract; LSS: SEVERE ACHONDRODYSPLASIA WITH DEVELOPMENTAL DELAY AND ACANTHOSIS NIGRICANS",
+      "alternativeSequence": "T",
+      "begin": "650",
+      "end": "650",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM731",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=731"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913105",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913105"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "18231634",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/18231634",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/18231634"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15026322",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15026322",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15026322"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12743143",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12743143",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12743143"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "18772890",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/18772890",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/18772890"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:473",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=473"
+          }
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806163A>C",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: HYPOCHONDROPLASIA; LSS: THANATOPHORIC DYSPLASIA, TYPE II; LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "Q",
+      "begin": "650",
+      "end": "650",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs78311289",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs78311289"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM726",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=726"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8754806",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8754806",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8754806"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11055896",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11055896",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11055896"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17668422",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17668422",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17668422"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11314002",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11314002",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11314002"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15897885",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15897885",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15897885"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11314002",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11314002",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11314002"
+          }
+        }
+
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806162A>C",
+      "association":
+      [
+
+        {
+
+          "name": "Bladder cancer (BLC)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "109800",
+              "url": "http://www.omim.org/entry/109800"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): upper aerodigestive tract, large intestine; LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "N",
+      "begin": "650",
+      "end": "650",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM1428730",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428730"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs28928868",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs28928868"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24667986",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24667986",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24667986"
+          }
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806164G>C",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "constitutively activated kinase with impaired internalization and degradation, resulting in prolonged FGFR3 signaling  Ftid: VAR_004161; LSS: primary tissue(s): haematopoietic and lymphoid tissue, skin, urinary tract; LSS: SEVERE ACHONDRODYSPLASIA WITH DEVELOPMENTAL DELAY AND ACANTHOSIS NIGRICANS",
+      "alternativeSequence": "M",
+      "begin": "650",
+      "end": "650",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM720",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=720"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913105",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913105"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10053006",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10053006",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10053006"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15026322",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15026322",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15026322"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16040860",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16040860",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16040860"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10671061",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10671061",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10671061"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17509076",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17509076",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17509076"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9207791",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9207791",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9207791"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17392824",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17392824",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17392824"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17561467",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17561467",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17561467"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17585316",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17585316",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17585316"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21533174",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21533174",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21533174"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9207791",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9207791",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9207791"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "18503601",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/18503601",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/18503601"
+          }
+        }
+
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806163A>T",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Achondroplasia (ACH)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "100800",
+              "url": "http://www.omim.org/entry/100800"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Thanatophoric dysplasia 1 (TD1)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "187600",
+              "url": "http://www.omim.org/entry/187600"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Achondroplasia, severe, with developmental delay and acanthosis nigricans (SADDAN)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "616482",
+              "url": "http://www.omim.org/entry/616482"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic,disease,disease,disease,disease,disease,disease,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "bladder transitional cell carcinoma; somatic mutation; constitutively activated kinase with impaired internalization and degradation, resulting in prolonged FGFR3 signaling  Ftid: VAR_004160; LSS: primary tissue(s): testis, urinary tract, skin, haematopoietic and lymphoid tissue, central nervous system; LSS: THANATOPHORIC DYSPLASIA, TYPE II; LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "E",
+      "begin": "650",
+      "end": "650",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM719",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=719"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs78311289",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs78311289"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8754806",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8754806",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8754806"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "14534538",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/14534538",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/14534538"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:329",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=329"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19855393",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19855393",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19855393"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11529856",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11529856",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11529856"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17585316",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17585316",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17585316"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21533174",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21533174",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21533174"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12297284",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12297284",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12297284"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7773297",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7773297",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7773297"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:552",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=552"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17145761",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17145761",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17145761"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10471491",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10471491",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10471491"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12139740",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12139740",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12139740"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17392824",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17392824",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17392824"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11294897",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11294897",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11294897"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17561467",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17561467",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17561467"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11429702",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11429702",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11429702"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19855393",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19855393",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19855393"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17344846",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17344846",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17344846"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9207791",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9207791",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9207791"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:30",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=30"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:34",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=34"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "18772890",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/18772890",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/18772890"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23917401",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23917401",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23917401"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16778799",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16778799",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16778799"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:473",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=473"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19955487",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19955487",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19955487"
+          }
+        }
+
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 1,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806162A>G",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Thanatophoric dysplasia 2 (TD2)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "187601",
+              "url": "http://www.omim.org/entry/187601"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Testicular germ cell tumor (TGCT)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "273300",
+              "url": "http://www.omim.org/entry/273300"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Bladder cancer (BLC)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "109800",
+              "url": "http://www.omim.org/entry/109800"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic,disease,disease,disease,pathogenic,disease,disease,disease,disease,disease,disease,disease,disease,disease,disease,disease,disease,disease,disease,pathogenic,disease,disease,disease,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "64",
+      "end": "64",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs763406515",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs763406515"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.952,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.65,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799335C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "Y",
+      "begin": "646",
+      "end": "646",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM34149",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=34149"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19694823",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19694823",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19694823"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806150G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_042210; LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "N",
+      "begin": "646",
+      "end": "646",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428726",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428726"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17344846",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17344846",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17344846"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806150G>A",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "G",
+      "begin": "646",
+      "end": "646",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428728",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428728"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806151A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "R",
+      "begin": "643",
+      "end": "643",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428724",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428724"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806142A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "D",
+      "begin": "643",
+      "end": "643",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29439",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29439"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806141C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "642",
+      "end": "642",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771059356",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771059356"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.989,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806138G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "N",
+      "begin": "641",
+      "end": "641",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29438",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29438"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806135G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "G",
+      "begin": "641",
+      "end": "641",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428722",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428722"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.21,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806136A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin",
+      "alternativeSequence": "W",
+      "begin": "640",
+      "end": "640",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1694076",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1694076"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22842228",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22842228",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22842228"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:511",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=511"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806132C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "63",
+      "end": "63",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs371729802",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371729802"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.049,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.11,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799332C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "63",
+      "end": "63",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs371729802",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371729802"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.384,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799332C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "63",
+      "end": "63",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs371729802",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371729802"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.61,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799332C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): kidney",
+      "alternativeSequence": "W",
+      "begin": "637",
+      "end": "637",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM481085",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=481085"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:416",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=416"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806123G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): soft tissue",
+      "alternativeSequence": "L",
+      "begin": "636",
+      "end": "636",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM133158",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=133158"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs104886005",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs104886005"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21264207",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21264207",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21264207"
+          }
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99925005,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806122C>G",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "634",
+      "end": "634",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs573600072",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs573600072"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806115C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): upper aerodigestive tract",
+      "alternativeSequence": "M",
+      "begin": "630",
+      "end": "630",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29448",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29448"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19327639",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19327639",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19327639"
+          }
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806102G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "A",
+      "begin": "630",
+      "end": "630",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1566856",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1566856"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:375",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=375"
+          }
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.97,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806103T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "62",
+      "end": "62",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs533866031",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs533866031"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.004,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.75,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799328C>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "62",
+      "end": "62",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs778645659",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778645659"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.045,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.35,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799329C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "62",
+      "end": "62",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs533866031",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs533866031"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.75,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799328C>G",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "V",
+      "begin": "627",
+      "end": "627",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428720",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428720"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.87,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806094A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): soft tissue",
+      "alternativeSequence": "K",
+      "begin": "627",
+      "end": "627",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM133156",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=133156"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs200849753",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs200849753"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21264207",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21264207",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21264207"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.7085,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806093G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "G",
+      "begin": "627",
+      "end": "627",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428718",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428718"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.82,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806094A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "D",
+      "begin": "627",
+      "end": "627",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29437",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29437"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.011,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.3,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806095G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "626",
+      "end": "626",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs778449048",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778449048"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.18,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806090A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue; LSS: CAMPTODACTYLY, TALL STATURE, AND HEARING LOSS SYNDROME; Ftid: VAR_029108",
+      "alternativeSequence": "H",
+      "begin": "621",
+      "end": "621",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM327093",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=327093"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913113",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913113"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22675565",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22675565",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22675565"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:425",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=425"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23856246",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23856246",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23856246"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17033969",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17033969",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17033969"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:504",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=504"
+          }
+        }
+
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806076G>A",
+      "association":
+      [
+
+        {
+
+          "name": "Camptodactyly tall stature and hearing loss syndrome (CATSHL syndrome)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "610474",
+              "url": "http://www.omim.org/entry/610474"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "disease,disease,pathogenic",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "619",
+      "end": "619",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs753541491",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs753541491"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.958,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806070C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): upper aerodigestive tract",
+      "alternativeSequence": "G",
+      "begin": "617",
+      "end": "617",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29452",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29452"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19327639",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19327639",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19327639"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806064A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "N",
+      "begin": "614",
+      "end": "614",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1645268",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1645268"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:485",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=485"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23700467",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23700467",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23700467"
+          }
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1806055T>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "609",
+      "end": "609",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs142093553",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs142093553"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.995,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805930C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "606",
+      "end": "606",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs776884460",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs776884460"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805921A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "5",
+      "end": "5",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771133929",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771133929"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1793947G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "599",
+      "end": "599",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764571446",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764571446"
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805900A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "598",
+      "end": "598",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs544955705",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs544955705"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.23,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805896G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "597",
+      "end": "597",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772558079",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772558079"
+        }
+      ],
+      "wildType": "C",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.353,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.04,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805893T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "591",
+      "end": "591",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs780684393",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs780684393"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.066,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805877C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "591",
+      "end": "591",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs746774947",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs746774947"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.131,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.18,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805875T>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "591",
+      "end": "591",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs754840234",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs754840234"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.007,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.1,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805876T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "58",
+      "end": "58",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs374561001",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs374561001"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.472,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.42,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799316G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "589",
+      "end": "589",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778357",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778357"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805869C>G",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "586",
+      "end": "586",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs576023546",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs576023546"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.132,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805860G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "585",
+      "end": "585",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs761163163",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761163163"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.747,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.2,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805857C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "584",
+      "end": "584",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs145183329",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs145183329"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.63,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805855C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "584",
+      "end": "584",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759993319",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759993319"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.027,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.34,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805854C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "583",
+      "end": "583",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769341070",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769341070"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.026,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805852A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "583",
+      "end": "583",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769341070",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769341070"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.943,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805852A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): ovary",
+      "alternativeSequence": "F",
+      "begin": "582",
+      "end": "582",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM116113",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=116113"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:331",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=331"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21720365",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21720365",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21720365"
+          }
+        }
+      ],
+      "wildType": "C",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805849G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "580",
+      "end": "580",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs761196249",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761196249"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.117,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.32,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805842G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "57",
+      "end": "57",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs61735064",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs61735064"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.00159744,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.091,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799313G>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "575",
+      "end": "575",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs746824967",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs746824967"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.455,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.26,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805828T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "573",
+      "end": "573",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs745848425",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs745848425"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.993,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805822C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "572",
+      "end": "572",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs757421718",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs757421718"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805818C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "572",
+      "end": "572",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs377141691",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs377141691"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.997,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805819C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): central nervous system",
+      "alternativeSequence": "A",
+      "begin": "572",
+      "end": "572",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM42893",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=42893"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs757421718",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs757421718"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "18772890",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/18772890",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/18772890"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:473",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=473"
+          }
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.958875,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805818C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "569",
+      "end": "569",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs146672976",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs146672976"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.984,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805810C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "568",
+      "end": "568",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs753095502",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs753095502"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.736,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805807G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "567",
+      "end": "567",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759874872",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759874872"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805803C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "559",
+      "end": "559",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs775946807",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs775946807"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.062,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805780C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "559",
+      "end": "559",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768385286",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768385286"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.02,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.32,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805779G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "M",
+      "begin": "555",
+      "end": "555",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM303914",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=303914"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22869148",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22869148",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22869148"
+          }
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.98,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805767G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "553",
+      "end": "553",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs199544087",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199544087"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.975,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805761G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "553",
+      "end": "553",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs199544087",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199544087"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.446,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805761G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "54",
+      "end": "54",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs370940011",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs370940011"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799304G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: CAMPTODACTYLY, TALL STATURE, AND HEARING LOSS SYNDROME",
+      "alternativeSequence": "K",
+      "begin": "546",
+      "end": "546",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587777857",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587777857"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.993,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805661C>A",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "544",
+      "end": "544",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762781471",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762781471"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805654G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "in hypochondroplasia Ftid: VAR_004159; LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "T",
+      "begin": "540",
+      "end": "540",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs77722678",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs77722678"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9452043",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9452043",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9452043"
+          }
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.996,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805643A>C",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "in hypochondroplasia; mild Ftid: VAR_018389; LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "S",
+      "begin": "540",
+      "end": "540",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs77722678",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs77722678"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12707965",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12707965",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12707965"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10777366",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10777366",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10777366"
+          }
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.977,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805643A>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: HYPOCHONDROPLASIA; in hypochondroplasia Ftid: VAR_004158",
+      "alternativeSequence": "K",
+      "begin": "540",
+      "end": "540",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs28933068",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs28933068"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7670477",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7670477",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7670477"
+          }
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805644C>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "53",
+      "end": "53",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs201433984",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs201433984"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.006,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.37,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799302G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "in hypochondroplasia Ftid: VAR_004157; LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "V",
+      "begin": "538",
+      "end": "538",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs80053154",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs80053154"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10215410",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10215410",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10215410"
+          }
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.912,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805636A>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "F",
+      "begin": "538",
+      "end": "538",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM327098",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=327098"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:425",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=425"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22675565",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22675565",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22675565"
+          }
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805636A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "531",
+      "end": "531",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767090421",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767090421"
+        }
+      ],
+      "wildType": "M",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.378,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805616T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "52",
+      "end": "52",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs140087676",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs140087676"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.00119808,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.023,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.54,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799298G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "52",
+      "end": "52",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs751554185",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751554185"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.493,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.26,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799299G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "529",
+      "end": "529",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs754516664",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs754516664"
+        }
+      ],
+      "wildType": "M",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.409,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805609A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "526",
+      "end": "526",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs766053734",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs766053734"
+        }
+      ],
+      "wildType": "M",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.586,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805600A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "526",
+      "end": "526",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs751213196",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751213196"
+        }
+      ],
+      "wildType": "M",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.754,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805602G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "523",
+      "end": "523",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs765164423",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs765164423"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.886,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805591G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "523",
+      "end": "523",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs750175353",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750175353"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.993,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805592T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "520",
+      "end": "520",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778356",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778356"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.997,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805583C>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "517",
+      "end": "517",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs139707740",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs139707740"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.983,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805574A>G",
+      "clinicalSignificances": "uncertain significance",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "516",
+      "end": "516",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs779377617",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs779377617"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.893,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805570G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "516",
+      "end": "516",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs779377617",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs779377617"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.996,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805570G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "516",
+      "end": "516",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772276122",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772276122"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805571A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "514",
+      "end": "514",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771583472",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771583472"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.065,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805565C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_029887; LSS: LADD SYNDROME",
+      "alternativeSequence": "N",
+      "begin": "513",
+      "end": "513",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913112",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913112"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16501574",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16501574",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16501574"
+          }
+        }
+
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.052,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.19,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805561G>A",
+      "association":
+      [
+
+        {
+
+          "name": "Lacrimo-auriculo-dento-digital syndrome (LADDS)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "149730",
+              "url": "http://www.omim.org/entry/149730"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "513",
+      "end": "513",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs749863914",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs749863914"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.684,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.23,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805562A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "512",
+      "end": "512",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs778548356",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778548356"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.874,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.04,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805476G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "50",
+      "end": "50",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs765760358",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs765760358"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.17,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799293T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "I",
+      "begin": "505",
+      "end": "505",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs144546453",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs144546453"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428716",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428716"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "V",
+      "frequency": 5.99042E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.2975,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805455G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "503",
+      "end": "503",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs752724806",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs752724806"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.007,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.18,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805450T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "502",
+      "end": "502",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767356787",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767356787"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.183,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.24,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805446C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "500",
+      "end": "500",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs755145822",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs755145822"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.035,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.19,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805441C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): pancreas",
+      "alternativeSequence": "T",
+      "begin": "500",
+      "end": "500",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs751635116",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751635116"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM88800",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=88800"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19893451",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19893451",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19893451"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.42,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805440G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "49",
+      "end": "49",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759325576",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759325576"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.003,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.34,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799289T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "W",
+      "begin": "498",
+      "end": "498",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773735098",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773735098"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.968,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805434C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "496",
+      "end": "496",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778359",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778359"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.203,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805428A>G",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "494",
+      "end": "494",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762079212",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762079212"
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.108,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805423T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "493",
+      "end": "493",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs777253325",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs777253325"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805419G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "492",
+      "end": "492",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs745385417",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs745385417"
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.004,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.6,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805416A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "48",
+      "end": "48",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs777287621",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs777287621"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.212,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.32,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799288G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "R",
+      "begin": "485",
+      "end": "485",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs267606808",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs267606808"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.991,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805396A>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "481",
+      "end": "481",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769701323",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769701323"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.958,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805384G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "480",
+      "end": "480",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs200780581",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs200780581"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.291,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1805382G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "W",
+      "begin": "471",
+      "end": "471",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs533045918",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs533045918"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.966,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804968C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "471",
+      "end": "471",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs533045918",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs533045918"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.83,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804968C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "Q",
+      "begin": "469",
+      "end": "469",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428714",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428714"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.41,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804963G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): central nervous system",
+      "alternativeSequence": "K",
+      "begin": "466",
+      "end": "466",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM39419",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=39419"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "18772396",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/18772396",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/18772396"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.47,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804953G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "460",
+      "end": "460",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764488842",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764488842"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.846,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804936C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): endometrium",
+      "alternativeSequence": "K",
+      "begin": "456",
+      "end": "456",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1053504",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1053504"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:419",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.51,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804923G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "455",
+      "end": "455",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs144242294",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs144242294"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.272,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804920T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "451",
+      "end": "451",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs547391969",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs547391969"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.814,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804908C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "450",
+      "end": "450",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs56240927",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs56240927"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.00299521,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804906C>T",
+      "clinicalSignificances": "benign",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "44",
+      "end": "44",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs146080119",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs146080119"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.004,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799274G>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "449",
+      "end": "449",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs61735104",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs61735104"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.00419329,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.792,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.11,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804902C>T",
+      "clinicalSignificances": "benign",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "444",
+      "end": "444",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs761325047",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761325047"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.896,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804888C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_022169",
+      "alternativeSequence": "T",
+      "begin": "441",
+      "end": "441",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs17884368",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs17884368"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "id": "ref.4"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.02,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804878G>A",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "43",
+      "end": "43",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773786734",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773786734"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799271C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "439",
+      "end": "439",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs529493162",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs529493162"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.957,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804873G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "436",
+      "end": "436",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs142030909",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs142030909"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.792,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804864C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "434",
+      "end": "434",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772065909",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772065909"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.839,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804857A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "V",
+      "begin": "429",
+      "end": "429",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428712",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428712"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.004,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804843C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "429",
+      "end": "429",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs182935140",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs182935140"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.047,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804842G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "428",
+      "end": "428",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs138986264",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs138986264"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.008,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804840A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "425",
+      "end": "425",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs777965130",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs777965130"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.835,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804831T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): endometrium",
+      "alternativeSequence": "Q",
+      "begin": "421",
+      "end": "421",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs587778355",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778355"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM1053500",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1053500"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:419",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.9985,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.017499998,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804516G>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "420",
+      "end": "420",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762949938",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762949938"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804513A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "420",
+      "end": "420",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs369368608",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs369368608"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804514G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "419",
+      "end": "419",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773239816",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773239816"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804510T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "419",
+      "end": "419",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs770029887",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs770029887"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804509C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "418",
+      "end": "418",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs781361431",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs781361431"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804507C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "416",
+      "end": "416",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs146114742",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs146114742"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.841,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804500C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "V",
+      "begin": "414",
+      "end": "414",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs780428794",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs780428794"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428710",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428710"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.38,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804494A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "413",
+      "end": "413",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767109009",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767109009"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.648,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804492A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "413",
+      "end": "413",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs375687485",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs375687485"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.821,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804491A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "413",
+      "end": "413",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs140898926",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs140898926"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.611,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804493G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "P",
+      "begin": "412",
+      "end": "412",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs752460284",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs752460284"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.52,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804489A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "411",
+      "end": "411",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759057257",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759057257"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804485G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "411",
+      "end": "411",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759057257",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759057257"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.997,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804485G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "410",
+      "end": "410",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs751304574",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751304574"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.1,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804482A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "40",
+      "end": "40",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs748963805",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs748963805"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.103,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.33,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799263G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "408",
+      "end": "408",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs761877926",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761877926"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.24,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804477C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "406",
+      "end": "406",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs201751659",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs201751659"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.023,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.53,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804470C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "405",
+      "end": "405",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs201813356",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs201813356"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.347,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.65,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804468G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "405",
+      "end": "405",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768867257",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768867257"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.77,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804467G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "404",
+      "end": "404",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs747363570",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs747363570"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804465A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "404",
+      "end": "404",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs780415133",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs780415133"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804464A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "403",
+      "end": "403",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772301946",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772301946"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.507,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.12,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804462A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "403",
+      "end": "403",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs373640210",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs373640210"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.403,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804461A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "402",
+      "end": "402",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs374947075",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs374947075"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804458C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "402",
+      "end": "402",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs752194597",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs752194597"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.187,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.41,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804459C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "402",
+      "end": "402",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs752194597",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs752194597"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.438,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804459C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "401",
+      "end": "401",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762705505",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762705505"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.007,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.83,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804455C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "401",
+      "end": "401",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762705505",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762705505"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.019,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.76,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804455C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "401",
+      "end": "401",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762705505",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762705505"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.129,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.73,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804455C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "400",
+      "end": "400",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs373034495",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs373034495"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.044,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.22,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804452A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "39",
+      "end": "39",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769591617",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769591617"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.23,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799260C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): lung",
+      "alternativeSequence": "H",
+      "begin": "399",
+      "end": "399",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM340691",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=340691"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs761896295",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761896295"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:431",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=431"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22980975",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22980975",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22980975"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.013,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07875,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804450G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "C",
+      "begin": "399",
+      "end": "399",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM296687",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=296687"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs370064407",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs370064407"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22810696",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22810696",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22810696"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.76125,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804449C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "397",
+      "end": "397",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs542210035",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs542210035"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.087,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804444G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "397",
+      "end": "397",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs542210035",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs542210035"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.932,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804444G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "397",
+      "end": "397",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs576428377",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs576428377"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.953,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804443C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "394",
+      "end": "394",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs747694886",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs747694886"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.018,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804435C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_004156; LSS: primary tissue(s): urinary tract, skin; LSS: CROUZON SYNDROME WITH ACANTHOSIS NIGRICANS",
+      "alternativeSequence": "E",
+      "begin": "391",
+      "end": "391",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs28931615",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs28931615"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM721",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=721"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7493034",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7493034",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7493034"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16778799",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16778799",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16778799"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17935505",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17935505",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17935505"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16885334",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16885334",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16885334"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17527084",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17527084",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17527084"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17668422",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17668422",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17668422"
+          }
+        }
+
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.55009377,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804426C>A",
+      "association":
+      [
+
+        {
+
+          "name": "Crouzon syndrome with acanthosis nigricans (CAN)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "612247",
+              "url": "http://www.omim.org/entry/612247"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "disease,pathogenic,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): upper aerodigestive tract",
+      "alternativeSequence": "L",
+      "begin": "386",
+      "end": "386",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM123166",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=123166"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:349",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=349"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21798893",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21798893",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21798893"
+          }
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.68,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804412C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): endometrium",
+      "alternativeSequence": "M",
+      "begin": "385",
+      "end": "385",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1053498",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1053498"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:419",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=419"
+          }
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.87,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804407C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_022168; LSS: primary tissue(s): lung, haematopoietic and lymphoid tissue, urinary tract",
+      "alternativeSequence": "L",
+      "begin": "384",
+      "end": "384",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs17881656",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs17881656"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM724",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=724"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17344846",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17344846",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17344846"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23657946",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23657946",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23657946"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "id": "ref.4"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11157491",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11157491",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11157491"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:417",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=417"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "20824703",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/20824703",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/20824703"
+          }
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.48625,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804404T>C",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "384",
+      "end": "384",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs17881656",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs17881656"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 7.98722E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804404T>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "383",
+      "end": "383",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs11943863",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs11943863"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.19,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804402T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "D",
+      "begin": "382",
+      "end": "382",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM727",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=727"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11429702",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11429702",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11429702"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.49,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804399G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "382",
+      "end": "382",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs750161905",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750161905"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.141,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804399G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "381",
+      "end": "381",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs149023204",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs149023204"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.197,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804395G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "381",
+      "end": "381",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778776",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778776"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.091,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804396T>A",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "very common mutation; constitutively activated kinase with impaired internalization and degradation, resulting in prolonged FGFR3 signaling Ftid: VAR_004155; LSS: primary tissue(s): skin, urinary tract; LSS: ACHONDROPLASIA",
+      "alternativeSequence": "R",
+      "begin": "380",
+      "end": "380",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs28931614",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs28931614"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM24842",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=24842"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12297284",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12297284",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12297284"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17561467",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17561467",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17561467"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21533174",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21533174",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21533174"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16841094",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16841094",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16841094"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10611230",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10611230",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10611230"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7847369",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7847369",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7847369"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8078586",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8078586",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8078586"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8599935",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8599935",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8599935"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "20542753",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/20542753",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/20542753"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "20824703",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/20824703",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/20824703"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16841094",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16841094",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16841094"
+          }
+        }
+
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.7995312,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.23773436,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804392G>A",
+      "association":
+      [
+
+        {
+
+          "name": "Achondroplasia (ACH)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "100800",
+              "url": "http://www.omim.org/entry/100800"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "E",
+      "begin": "380",
+      "end": "380",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM51545",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=51545"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "20542753",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/20542753",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/20542753"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.64,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.28,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804393G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "37",
+      "end": "37",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs747890000",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs747890000"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.003,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.47,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799255A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: ACHONDROPLASIA",
+      "alternativeSequence": "R",
+      "begin": "377",
+      "end": "377",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs267606809",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs267606809"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.95,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804384T>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "377",
+      "end": "377",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764273223",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764273223"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.157,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.13,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804383C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "376",
+      "end": "376",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767787097",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767787097"
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.14,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804381T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "376",
+      "end": "376",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767787097",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767787097"
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.691,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804381T>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_004154; LSS: ACHONDROPLASIA",
+      "alternativeSequence": "C",
+      "begin": "375",
+      "end": "375",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs75790268",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs75790268"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7758520",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7758520",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7758520"
+          }
+        }
+
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.827,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804377G>T",
+      "association":
+      [
+
+        {
+
+          "name": "Achondroplasia (ACH)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "100800",
+              "url": "http://www.omim.org/entry/100800"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin, haematopoietic and lymphoid tissue, urinary tract; LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "C",
+      "begin": "373",
+      "end": "373",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM718",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=718"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913485",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913485"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:557",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=557"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11429702",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11429702",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11429702"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24360661",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24360661",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24360661"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8845844",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8845844",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8845844"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17585316",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17585316",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17585316"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22869148",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22869148",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22869148"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10360402",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10360402",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10360402"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17392824",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17392824",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17392824"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17509076",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17509076",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17509076"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9207791",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9207791",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9207791"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:556",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=556"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11529856",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11529856",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11529856"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121791",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121791",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121791"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+        }
+
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.6601329,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.009667968,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804372A>G",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Thanatophoric dysplasia 1 (TD1)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "187600",
+              "url": "http://www.omim.org/entry/187600"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "371",
+      "end": "371",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759980266",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759980266"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.184,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.45,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804366G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin, urinary tract; LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "C",
+      "begin": "371",
+      "end": "371",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM17461",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=17461"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913484",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913484"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7773297",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7773297",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7773297"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23657946",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23657946",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23657946"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:556",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=556"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19076977",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19076977",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19076977"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17585316",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17585316",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17585316"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121791",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121791",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121791"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19298285",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19298285",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19298285"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:557",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=557"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+        }
+
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.80937505,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0384375,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804365A>T",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin, urinary tract; LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "C",
+      "begin": "370",
+      "end": "370",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM716",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=716"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913479",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913479"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8845844",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8845844",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8845844"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:557",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=557"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17585316",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17585316",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17585316"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24360661",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24360661",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24360661"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16841094",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16841094",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16841094"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9790257",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9790257",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9790257"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17392824",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17392824",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17392824"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23657946",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23657946",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23657946"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:398",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=398"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10471491",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10471491",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10471491"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16841094",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16841094",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16841094"
+          }
+        }
+
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.027,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08125,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804362G>T",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Bladder cancer (BLC)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "109800",
+              "url": "http://www.omim.org/entry/109800"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "pathogenic,disease,disease,disease,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "T",
+      "begin": "36",
+      "end": "36",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428658",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428658"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.67,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794040G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "369",
+      "end": "369",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs146970233",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs146970233"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.283,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.22,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804360C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "368",
+      "end": "368",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs201136923",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs201136923"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.109,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.87,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804356G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "368",
+      "end": "368",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773566065",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773566065"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.016,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.75,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804357A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "367",
+      "end": "367",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs779695832",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs779695832"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.006,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804355C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "D",
+      "begin": "366",
+      "end": "366",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29435",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29435"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.57,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804351C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "365",
+      "end": "365",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs757980849",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs757980849"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.38,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804347G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "361",
+      "end": "361",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs745683500",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs745683500"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.103,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804336A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "360",
+      "end": "360",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs757013992",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs757013992"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.007,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.28,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804332G>C",
+      "clinicalSignificances": "uncertain significance",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "360",
+      "end": "360",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs757013992",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs757013992"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.4,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1804332G>A",
+      "clinicalSignificances": "uncertain significance",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "358",
+      "end": "358",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764613314",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764613314"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.05,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.12,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803833C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "355",
+      "end": "355",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs753223626",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs753223626"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.015,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803824G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "350",
+      "end": "350",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs762523796",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs762523796"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.012,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803809C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "349",
+      "end": "349",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs532318669",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs532318669"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.012,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.75,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803806C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "344",
+      "end": "344",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs199702395",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199702395"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.026,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803792C>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "C",
+      "begin": "342",
+      "end": "342",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778775",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778775"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.918,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803785G>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): oesophagus",
+      "alternativeSequence": "T",
+      "begin": "341",
+      "end": "341",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1243266",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1243266"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:464",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=464"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23525077",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23525077",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23525077"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803782G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "338",
+      "end": "338",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768739746",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768739746"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.633,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803774C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_042209",
+      "alternativeSequence": "M",
+      "begin": "338",
+      "end": "338",
+      "evidences":
+
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17344846",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17344846",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17344846"
+          }
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "disease": false,
+      "sourceType": "uniprot"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "335",
+      "end": "335",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772097747",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772097747"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803764G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: RECLASSIFIED - VARIANT OF UNKNOWN SIGNIFICANCE USHER SYNDROME, TYPE IC",
+      "alternativeSequence": "T",
+      "begin": "334",
+      "end": "334",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs373496046",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs373496046"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.763,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803761G>A",
+      "clinicalSignificances": "uncertain significance",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "331",
+      "end": "331",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs757430342",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs757430342"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.392,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.23,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803753T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "32",
+      "end": "32",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs754103775",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs754103775"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.002,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.36,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794028G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "329",
+      "end": "329",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs188723332",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs188723332"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 5.99042E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.999,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803746G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "328",
+      "end": "328",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778817",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778817"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.956,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803744A>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "328",
+      "end": "328",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs781716463",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs781716463"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.923,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803743A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "327",
+      "end": "327",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs372315097",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs372315097"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803741A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "327",
+      "end": "327",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs749886786",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs749886786"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.011,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803742C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "324",
+      "end": "324",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778816",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778816"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.946,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803731C>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "323",
+      "end": "323",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs753520867",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs753520867"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.007,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.14,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803728G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine, pancreas; LSS: COLORECTAL CANCER, SOMATIC; in colorectal cancer Ftid: VAR_018388",
+      "alternativeSequence": "K",
+      "begin": "322",
+      "end": "322",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM728",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=728"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913111",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913111"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21447618",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21447618",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21447618"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11325814",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11325814",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11325814"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11325814",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11325814",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11325814"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.021,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803725G>A",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "*",
+      "begin": "322",
+      "end": "322",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428707",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428707"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803725G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "319",
+      "end": "319",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs775299111",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs775299111"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.456,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803717A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "318",
+      "end": "318",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771975162",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771975162"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.576,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.21,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803713G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "317",
+      "end": "317",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs774439963",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs774439963"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.008,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.04,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803710A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "315",
+      "end": "315",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs371410933",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371410933"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.217,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803705A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "315",
+      "end": "315",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs777969410",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs777969410"
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.675,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803704A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "314",
+      "end": "314",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs770204082",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs770204082"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.004,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803702C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "314",
+      "end": "314",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs748488719",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs748488719"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.015,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.07,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803701G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "312",
+      "end": "312",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs778617562",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778617562"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.311,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803696C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "312",
+      "end": "312",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs778617562",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778617562"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.609,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803696C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "311",
+      "end": "311",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs761527653",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761527653"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.896,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1803693C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "310",
+      "end": "310",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs760206152",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs760206152"
+        }
+      ],
+      "wildType": "K",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.393,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1802023A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "30",
+      "end": "30",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs756437064",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs756437064"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.568,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.11,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794023G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "308",
+      "end": "308",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs774929566",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs774929566"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.918,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1802017G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "306",
+      "end": "306",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs774047997",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs774047997"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.833,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1802011G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "*",
+      "begin": "305",
+      "end": "305",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs144675978",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs144675978"
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1802010C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "302",
+      "end": "302",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs748261686",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs748261686"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.975,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801999G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin",
+      "alternativeSequence": "D",
+      "begin": "302",
+      "end": "302",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM1694074",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1694074"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs371176140",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs371176140"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:511",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=511"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22842228",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22842228",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22842228"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.98075,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.0725,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1802000G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "301",
+      "end": "301",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs377588489",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs377588489"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.228,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.1,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801998C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "300",
+      "end": "300",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs780313125",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs780313125"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.021,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801994C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "29",
+      "end": "29",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs553265665",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs553265665"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.235,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.12,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794021G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "D",
+      "begin": "294",
+      "end": "294",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428694",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428694"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "N",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.79,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801975A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "28",
+      "end": "28",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768021369",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768021369"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.159,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.21,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794016G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "285",
+      "end": "285",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs765988008",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs765988008"
+        }
+      ],
+      "wildType": "I",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.714,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801948A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "283",
+      "end": "283",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769692611",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769692611"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.986,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801942C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "S",
+      "begin": "283",
+      "end": "283",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM254688",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=254688"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:398",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=398"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21822268",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21822268",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21822268"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:557",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=557"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801942C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "283",
+      "end": "283",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773094879",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773094879"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.973,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801943C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "282",
+      "end": "282",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs761883478",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs761883478"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.981,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.12,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801941G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): lung",
+      "alternativeSequence": "G",
+      "begin": "280",
+      "end": "280",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM396078",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=396078"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22980975",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22980975",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22980975"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:431",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=431"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.26,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801934A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: ACHONDROPLASIA",
+      "alternativeSequence": "C",
+      "begin": "279",
+      "end": "279",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913114",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913114"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.992,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801930A>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: HYPOCHONDROPLASIA",
+      "alternativeSequence": "C",
+      "begin": "278",
+      "end": "278",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913115",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913115"
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.967,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801928A>G",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "274",
+      "end": "274",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768680057",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768680057"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.191,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.66,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801916A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "C",
+      "begin": "273",
+      "end": "273",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM330456",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=330456"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22573403",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22573403",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22573403"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:432",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=432"
+          }
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801913T>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "270",
+      "end": "270",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs780147591",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs780147591"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.08,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.4,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801903G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "M",
+      "begin": "266",
+      "end": "266",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29434",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29434"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.68,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801891G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "265",
+      "end": "265",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs779284979",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs779284979"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.01,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.72,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801889C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin",
+      "alternativeSequence": "T",
+      "begin": "265",
+      "end": "265",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs151254213",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs151254213"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM107802",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=107802"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:348",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=348"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21499247",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21499247",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21499247"
+          }
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.41,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.185,
+      "somaticStatus": 1,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801888G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "264",
+      "end": "264",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs778283906",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs778283906"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.26,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801885A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "264",
+      "end": "264",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778773",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778773"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.988,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801886C>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "L",
+      "begin": "260",
+      "end": "260",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs751038752",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751038752"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428692",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428692"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.959,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801874C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "256",
+      "end": "256",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778354",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778354"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.894,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801863G>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "252",
+      "end": "252",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs750072225",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750072225"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.05,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801850G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "251",
+      "end": "251",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs377554120",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs377554120"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.944,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801848C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "250",
+      "end": "250",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs373470718",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs373470718"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.176,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801843C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "Ftid: VAR_004150; LSS: MUENKE SYNDROME",
+      "alternativeSequence": "R",
+      "begin": "250",
+      "end": "250",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs4647924",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs4647924"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11746040",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11746040",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11746040"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9525367",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9525367",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9525367"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9950359",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9950359",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9950359"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "9042914",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/9042914",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/9042914"
+          }
+        }
+
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.954,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801844C>G",
+      "association":
+      [
+
+        {
+
+          "name": "Muenke syndrome (MNKS)",
+          "description": "also some individuals with autosomal dominant congenital sensorineural deafness without craniosynostosis",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "602849",
+              "url": "http://www.omim.org/entry/602849"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "disease,disease,disease,not provided,pathogenic,disease,disease,disease,not provided,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "T",
+      "begin": "249",
+      "end": "249",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM29431",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=29431"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19287463",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19287463",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19287463"
+          }
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.081,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.26,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801840T>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "F",
+      "begin": "249",
+      "end": "249",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913483",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913483"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.928,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801841C>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: THANATOPHORIC DYSPLASIA, TYPE I; LSS: primary tissue(s): upper aerodigestive tract, cervix, lung, urinary tract, skin",
+      "alternativeSequence": "C",
+      "begin": "249",
+      "end": "249",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "dbSNP",
+          "id": "rs121913483",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913483"
+
+        },
+
+        {
+          "name": "cosmic",
+          "id": "COSM715",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=715"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8589699",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8589699",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8589699"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10471491",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10471491",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10471491"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19845664",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19845664",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19845664"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10360402",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10360402",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10360402"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "20664185",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/20664185",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/20664185"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22229528",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22229528",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22229528"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:418",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=418"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:557",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=557"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11114733",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11114733",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11114733"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11466624",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11466624",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11466624"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11605053",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11605053",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11605053"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "23657946",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/23657946",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/23657946"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24667986",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24667986",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24667986"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8845844",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8845844",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8845844"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10471491",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10471491",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10471491"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:413",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=413"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21984968",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21984968",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21984968"
+          }
+        }
+
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.95,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.106873475,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801841C>G",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Bladder cancer (BLC)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "109800",
+              "url": "http://www.omim.org/entry/109800"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "disease,disease,disease,disease,pathogenic,disease,disease,disease,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "severe and lethal; also found as somatic mutation in one patient with multiple myeloma; constitutive dimerization and kinase activation  Ftid: VAR_004148; LSS: primary tissue(s): haematopoietic and lymphoid tissue, lung, skin, upper aerodigestive tract, urinary tract; LSS: THANATOPHORIC DYSPLASIA, TYPE I",
+      "alternativeSequence": "C",
+      "begin": "248",
+      "end": "248",
+      "xrefs":
+
+      [
+
+        {
+
+          "name": "cosmic",
+          "id": "COSM714",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=714"
+
+        },
+
+        {
+          "name": "dbSNP",
+          "id": "rs121913482",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs121913482"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10360402",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10360402",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10360402"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:398",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=398"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "15772091",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/15772091",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/15772091"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "10471491",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/10471491",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/10471491"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "21984968",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/21984968",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/21984968"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "8845844",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/8845844",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/8845844"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17509076",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17509076",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17509076"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11529856",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11529856",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11529856"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:581",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=581"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19327639",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19327639",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19327639"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19845664",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19845664",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19845664"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "16841094",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/16841094",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/16841094"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "7773297",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/7773297",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/7773297"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:418",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=418"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19298285",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19298285",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19298285"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24121792",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24121792",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24121792"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:557",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=557"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "11529856",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/11529856",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/11529856"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "19076977",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/19076977",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/19076977"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "24360661",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/24360661",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/24360661"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12368157",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12368157",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12368157"
+          }
+        }
+
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.930004,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 1,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801837C>T",
+      "association":
+      [
+
+        {
+
+          "name": "Keratosis, seborrheic (KERSEB)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "182000",
+              "url": "http://www.omim.org/entry/182000"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Bladder cancer (BLC)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "109800",
+              "url": "http://www.omim.org/entry/109800"
+            }
+          ]
+
+        },
+        {
+
+          "name": "Thanatophoric dysplasia 1 (TD1)",
+          "xrefs":
+
+          [
+
+            {
+              "name": "OMIM",
+              "id": "187600",
+              "url": "http://www.omim.org/entry/187600"
+            }
+          ]
+        }
+      ],
+      "clinicalSignificances": "disease,disease,disease,disease,disease,disease,disease,disease,disease,pathogenic,disease,disease,disease,disease,pathogenic,disease",
+      "disease": true,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "247",
+      "end": "247",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs565612580",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs565612580"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.643,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801743G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "242",
+      "end": "242",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs150916178",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs150916178"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.903,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.13,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801729C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "242",
+      "end": "242",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767373970",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767373970"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.314,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.78,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801728A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "C",
+      "begin": "241",
+      "end": "241",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM13247",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=13247"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "12835230",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/12835230",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/12835230"
+          }
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801726A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "240",
+      "end": "240",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs759641808",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs759641808"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.986,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801723C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "23",
+      "end": "23",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs768338767",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs768338767"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.054,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.39,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794002A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "23",
+      "end": "23",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs776259575",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs776259575"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.132,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.3,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1794003G>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "W",
+      "begin": "238",
+      "end": "238",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs766423062",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs766423062"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "possibly damaging",
+      "polyphenScore": 0.846,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801716C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "238",
+      "end": "238",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs199944818",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199944818"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 7.98722E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.015,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.24,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801717G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "236",
+      "end": "236",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs200495316",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs200495316"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.021,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.04,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801711G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "D",
+      "begin": "235",
+      "end": "235",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1309921",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1309921"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:413",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=413"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801708G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "234",
+      "end": "234",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773302522",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773302522"
+        }
+      ],
+      "wildType": "F",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.314,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.38,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801704T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "229",
+      "end": "229",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs368831528",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs368831528"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.746,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.48,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801689G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "229",
+      "end": "229",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs368831528",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs368831528"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.177,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.51,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801689G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "in a colorectal adenocarcinoma sample; somatic mutation Ftid: VAR_042208; LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "R",
+      "begin": "228",
+      "end": "228",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM20458",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=20458"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000269",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "17344846",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/17344846",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/17344846"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:28",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=28"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:34",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=34"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "C",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.97,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 1,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801686T>C",
+      "clinicalSignificances": "DISEASE",
+      "disease": false,
+      "sourceType": "mixed"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "H",
+      "begin": "226",
+      "end": "226",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM327092",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=327092"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:425",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=425"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22675565",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22675565",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22675565"
+          }
+        }
+      ],
+      "wildType": "Y",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.46,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801680T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "N",
+      "begin": "222",
+      "end": "222",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1309919",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1309919"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:413",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=413"
+          }
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801668G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "221",
+      "end": "221",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs752393208",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs752393208"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.946,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801666C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "21",
+      "end": "21",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778351",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778351"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.02,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.13,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1793996C>A",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "218",
+      "end": "218",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs766513208",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs766513208"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.029,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.11,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801657T>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): urinary tract",
+      "alternativeSequence": "K",
+      "begin": "216",
+      "end": "216",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1309917",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1309917"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:413",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=413"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.98,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801650G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "216",
+      "end": "216",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs750672389",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750672389"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.978,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801651A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "*",
+      "begin": "211",
+      "end": "211",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs369033272",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs369033272"
+        }
+      ],
+      "wildType": "W",
+      "frequency": 0.0,
+      "polyphenScore": 0.0,
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801637G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "208",
+      "end": "208",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs769124009",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs769124009"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.723,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.4,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801626C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "200",
+      "end": "200",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778353",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778353"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.988,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801520G>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): haematopoietic and lymphoid tissue",
+      "alternativeSequence": "H",
+      "begin": "200",
+      "end": "200",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM327096",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=327096"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:425",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=425"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22675565",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22675565",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22675565"
+          }
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801520G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "S",
+      "begin": "197",
+      "end": "197",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs754122254",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs754122254"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.18,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801510G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "194",
+      "end": "194",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs756575558",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs756575558"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.965,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801502A>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine, haematopoietic and lymphoid tissue",
+      "alternativeSequence": "K",
+      "begin": "194",
+      "end": "194",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM327094",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=327094"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:425",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=425"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22675565",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22675565",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22675565"
+          }
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.71,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801501G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Y",
+      "begin": "187",
+      "end": "187",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs767900565",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs767900565"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.008,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801481C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): large intestine",
+      "alternativeSequence": "D",
+      "begin": "180",
+      "end": "180",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1428671",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1428671"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:376",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=376"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801460G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "179",
+      "end": "179",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs764712450",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs764712450"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.698,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.35,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801456G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "175",
+      "end": "175",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs775241791",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs775241791"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.988,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801445G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "172",
+      "end": "172",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs529408918",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs529408918"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.272,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.04,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801435G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "164",
+      "end": "164",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs577990843",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs577990843"
+        }
+      ],
+      "wildType": "L",
+      "frequency": 9.98403E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.612,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.62,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801411C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "15",
+      "end": "15",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs573850631",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs573850631"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.35,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1793977G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "158",
+      "end": "158",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs745863884",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs745863884"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.627,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.05,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801394G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "149",
+      "end": "149",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs749337219",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs749337219"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.008,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.97,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1801367G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "147",
+      "end": "147",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs773269128",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs773269128"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799806G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "146",
+      "end": "146",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs770008395",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs770008395"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.023,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.24,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799803G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "144",
+      "end": "144",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs748192608",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs748192608"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.5,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799798C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "G",
+      "begin": "143",
+      "end": "143",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs781302593",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs781302593"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.007,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799795A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "140",
+      "end": "140",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs542749920",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs542749920"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.575,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.38,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799785G>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "140",
+      "end": "140",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs542749920",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs542749920"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.197,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.58,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799785G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "V",
+      "begin": "13",
+      "end": "13",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs772001869",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs772001869"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.63,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1793972C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "139",
+      "end": "139",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs3135867",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs3135867"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0201677,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.023,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.43,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799784C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "A",
+      "begin": "139",
+      "end": "139",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs376268669",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs376268669"
+        }
+      ],
+      "wildType": "D",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.371,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799783A>C",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "137",
+      "end": "137",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs750990333",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750990333"
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.208,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799776G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "135",
+      "end": "135",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs774962503",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs774962503"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799770G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "description": "LSS: primary tissue(s): skin",
+      "alternativeSequence": "E",
+      "begin": "132",
+      "end": "132",
+      "xrefs":
+
+      [
+
+        {
+          "name": "cosmic",
+          "id": "COSM1694072",
+          "url": "http://cancer.sanger.ac.uk/cosmic/mutation/overview?id=1694072"
+        }
+
+      ],
+      "evidences":
+      [
+
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "PubMed",
+            "id": "22842228",
+            "url": "http://www.ncbi.nlm.nih.gov/pubmed/22842228",
+            "alternativeUrl": "http://europepmc.org/abstract/MED/22842228"
+          }
+
+        },
+        {
+
+          "code": "ECO:0000313",
+          "source":
+
+          {
+            "name": "cosmic_study",
+            "id": "COSU:511",
+            "url": "http://cancer.sanger.ac.uk/cosmic/study/overview?study_id=511"
+          }
+        }
+      ],
+      "wildType": "G",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799762G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "131",
+      "end": "131",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs766911583",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs766911583"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.998,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799759C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "130",
+      "end": "130",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs113172184",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs113172184"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.99,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.06,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799756C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "129",
+      "end": "129",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs751165912",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs751165912"
+        }
+      ],
+      "wildType": "P",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.012,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.36,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799753C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "128",
+      "end": "128",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs200300532",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs200300532"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.005,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.09,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799749G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "W",
+      "begin": "124",
+      "end": "124",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs199740841",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs199740841"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 0.967,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799514C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "124",
+      "end": "124",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs774749538",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs774749538"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.627,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.45,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799515G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "N",
+      "begin": "120",
+      "end": "120",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs771188160",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs771188160"
+        }
+      ],
+      "wildType": "H",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.0,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.79,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799502C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "I",
+      "begin": "117",
+      "end": "117",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs554790290",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs554790290"
+        }
+      ],
+      "wildType": "V",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.003,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.58,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799493G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "H",
+      "begin": "116",
+      "end": "116",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs569221269",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs569221269"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 1.99681E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.16,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799491G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "L",
+      "begin": "115",
+      "end": "115",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778769",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778769"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.028,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.36,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799488A>T",
+      "clinicalSignificances": "pathogenic",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "E",
+      "begin": "115",
+      "end": "115",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs746468796",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs746468796"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 1.0,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799487C>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "M",
+      "begin": "114",
+      "end": "114",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs779882318",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs779882318"
+        }
+      ],
+      "wildType": "T",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.283,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.03,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799485C>T",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "112",
+      "end": "112",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs758163128",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs758163128"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.004,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.18,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799479G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "R",
+      "begin": "111",
+      "end": "111",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs750076470",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs750076470"
+        }
+      ],
+      "wildType": "Q",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.001,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.51,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799476A>G",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "Q",
+      "begin": "110",
+      "end": "110",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs556916370",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs556916370"
+        }
+      ],
+      "wildType": "R",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.023,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.33,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799473G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "T",
+      "begin": "106",
+      "end": "106",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs369634049",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs369634049"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.008,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.14,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799460G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "D",
+      "begin": "106",
+      "end": "106",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs756994930",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs756994930"
+        }
+      ],
+      "wildType": "A",
+      "frequency": 0.0,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.356,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.15,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799461C>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "K",
+      "begin": "102",
+      "end": "102",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs558935109",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs558935109"
+        }
+      ],
+      "wildType": "E",
+      "frequency": 3.99361E-4,
+      "polyphenPrediction": "benign",
+      "polyphenScore": 0.735,
+      "siftPrediction": "tolerated",
+      "siftScore": 0.08,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799448G>A",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "F",
+      "begin": "100",
+      "end": "100",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778352",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778352"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.01,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799443C>T",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+
+    },
+    {
+
+      "type": "VARIANT",
+      "alternativeSequence": "C",
+      "begin": "100",
+      "end": "100",
+      "xrefs":
+
+      [
+
+        {
+          "name": "dbSNP",
+          "id": "rs587778352",
+          "url": "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?type=rs&rs=rs587778352"
+        }
+      ],
+      "wildType": "S",
+      "frequency": 0.0,
+      "polyphenPrediction": "probably damaging",
+      "polyphenScore": 1.0,
+      "siftPrediction": "deleterious",
+      "siftScore": 0.02,
+      "somaticStatus": 0,
+      "cytogeneticBand": "4p16.3",
+      "genomicLocation": "4:g.1799443C>G",
+      "clinicalSignificances": "not provided",
+      "disease": false,
+      "sourceType": "large_scale_study"
+    }
+  ]
+
+}

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -123,7 +123,7 @@ var Constants = function() {
     }, getTrackInfo: function(name) {
       return this.getTrackNames()[name];
     }
-  }
+  };
 }();
 
 module.exports = Constants;

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -548,7 +548,7 @@ FeaturesViewer.prototype.loadZoom = function(d) {
   updateViewportFromChart(fv);
   updateZoomFromChart(fv);
   fv.dispatcher.ready(d);
-}
+};
 
 FeaturesViewer.prototype.drawCategories = function(data, type, fv, container) {
   _.each(data, function(category) {

--- a/src/TrackFactory.js
+++ b/src/TrackFactory.js
@@ -1,5 +1,6 @@
 /*jslint node: true */
 /*jshint laxbreak: true */
+/*jshint laxcomma: true */
 "use strict";
 
 var d3 = require("d3");

--- a/src/VariantFilterDialog.js
+++ b/src/VariantFilterDialog.js
@@ -69,10 +69,10 @@ var VariantFilterDialog = function(container, variantViewer) {
   container.append('h4').text('Filter consequence');
   var ul = container.append('ul')
     .attr('class', 'up_pftv_dialog-container');
-  variantFilterDialog.dialog
+
   _.each(filters, function(filter) {
     var li = ul.append('li');
-    drawFilter(filter, li)
+    drawFilter(filter, li);
   });
 
   return variantFilterDialog;
@@ -84,7 +84,7 @@ var getBackground = function(filter) {
   } else {
     return 'background-color:' + (filter.on ? '#ffffff' : filter.color);
   }
-}
+};
 
 var filterData = function(data) {
   var activeFilters = _.filter(filters, 'on');
@@ -102,7 +102,7 @@ var filterData = function(data) {
           }
         });
         return discard;
-      })
+      });
     });
     var featureCopy = $.extend(true, {}, feature);
     featureCopy.variants = filtered;
@@ -119,6 +119,6 @@ var displayFeature = function(feature) {
     display = display || parentDisplay;
   });
   return display;
-}
+};
 
 module.exports = VariantFilterDialog;

--- a/src/VariantViewer.js
+++ b/src/VariantViewer.js
@@ -196,7 +196,7 @@ var VariantViewer = function(catTitle, features, container, fv, variantHeight, t
     this.updateData = function(data) {
       dataSeries.datum(data);
       this.update();
-    }
+    };
 
     return this;
 };

--- a/src/dataLoader.js
+++ b/src/dataLoader.js
@@ -7,96 +7,116 @@ var _ = require('underscore');
 var Evidence = require('./Evidence');
 var Constants = require('./Constants');
 
-var DataLoader = function() {
-  return {
-    get: function(url) {
-      return $.getJSON(url);
-    }, // processData: function(d) {
-    //   var consecutive = 0;
-    //   _.each(d, function(datum) {
-    //     if (datum && datum.features) {
-    //       _.each(datum.features, function(feature) {
-    //         if (feature.variants) {
-    //           _.each(feature.variants, function(variant) {
-    //             variant.internalId = "ft_" + consecutive;
-    //             variant.type.label = variant.type.label.replace('_', ' ');
-    //             consecutive++;
-    //           });
-    //         } else {
-    //           feature.internalId = "ft_" + consecutive;
-    //           feature.type.label = feature.type.label.replace('_', ' ');
-    //           consecutive++;
-    //         }
-    //       });
-    //     }
-    //   });
-    //   d.totalFeatureCount = consecutive;
-    //   return d;
-    // },
-    groupFeaturesByCategory: function(features) {
-      var categories = _.groupBy(features, function(d) {
-        return d.category;
-      });
-      delete categories.VARIANTS;
-      var orderedPairs = [];
-      var categoriesNames = Constants.getCategoryNamesInOrder();
-      _.each(categoriesNames, function(name){
-        if(categories[_.keys(name)[0]]){
-          orderedPairs.push([
-            _.keys(name)[0],
-            categories[_.keys(name)[0]]
-          ]);
+var groupEvidencesByCode = function(features) {
+    _.each(features, function(ft) {
+        if (ft.evidences) {
+            var evidences = {};
+            _.each(ft.evidences, function(ev) {
+                if (evidences[ev.code]) {
+                    evidences[ev.code].push(ev.source);
+                } else {
+                    evidences[ev.code] = [ev.source];
+                }
+            });
+            ft.evidences = evidences;
         }
-      });
-      return orderedPairs;
-    },
-    processProteomics: function(features) {
-      var types = _.map(features, function(d){
-        d.unique ? d.type = 'unique' : d.type = 'non_unique';
-        return d;
-      });
-      return [['PROTEOMICS',types]];
-    },
-    processUngroupedFeatures: function(features) {
-      return [[features[0].type, features]];
-    },
-    processVariants: function(variants, sequence) {
-      var mutationArray = [];
-        mutationArray.push({
-          'type': 'VARIANT',
-          'normal': '-',
-          'pos': 0,
-          'variants': []
-        });
-        var seq = sequence.split('');
-        _.each(seq, function(d, i) {
-          mutationArray.push({
-            'type': 'VARIANT',
-            'normal': seq[i],
-            'pos': i + 1,
-            'variants': []
-          });
-        });
-        mutationArray.push({
-          'type': 'VARIANT',
-          'normal': '-',
-          'pos': seq.length + 1,
-          'variants': []
-        });
+    });
+    return features;
+};
 
-        _.each(variants, function(d) {
-          d.begin = +d.begin;
-          d.wildType = d.wildType ? d.wildType : mutationArray[d.begin].normal;
-          d.sourceType = d.sourceType.toLowerCase();
-          if ((1 <= d.begin) && (d.begin <= seq.length)) {
-            mutationArray[d.begin].variants.push(d);
-          } else if ((seq.length + 1) === d.begin) {
-            mutationArray[d.begin - 1].variants.push(d);
-          }
-        });
-      return [['VARIATION', mutationArray]];
-    }
-  };
+var DataLoader = function() {
+    return {
+        get: function(url) {
+          return $.getJSON(url);
+        }, // processData: function(d) {
+        //   var consecutive = 0;
+        //   _.each(d, function(datum) {
+        //     if (datum && datum.features) {
+        //       _.each(datum.features, function(feature) {
+        //         if (feature.variants) {
+        //           _.each(feature.variants, function(variant) {
+        //             variant.internalId = "ft_" + consecutive;
+        //             variant.type.label = variant.type.label.replace('_', ' ');
+        //             consecutive++;
+        //           });
+        //         } else {
+        //           feature.internalId = "ft_" + consecutive;
+        //           feature.type.label = feature.type.label.replace('_', ' ');
+        //           consecutive++;
+        //         }
+        //       });
+        //     }
+        //   });
+        //   d.totalFeatureCount = consecutive;
+        //   return d;
+        // },
+        groupFeaturesByCategory: function(features) {
+            features = groupEvidencesByCode(features);
+            var categories = _.groupBy(features, function(d) {
+                return d.category;
+            });
+            delete categories.VARIANTS;
+            var orderedPairs = [];
+            var categoriesNames = Constants.getCategoryNamesInOrder();
+            _.each(categoriesNames, function(name){
+                if(categories[_.keys(name)[0]]){
+                    orderedPairs.push([
+                        _.keys(name)[0],
+                        categories[_.keys(name)[0]]
+                    ]);
+                }
+            });
+            return orderedPairs;
+        },
+        processProteomics: function(features) {
+            features = groupEvidencesByCode(features);
+            var types = _.map(features, function(d){
+                d.unique ? d.type = 'unique' : d.type = 'non_unique';
+                return d;
+            });
+            return [['PROTEOMICS',types]];
+        },
+        processUngroupedFeatures: function(features) {
+            return [[features[0].type, features]];
+        },
+        processVariants: function(variants, sequence) {
+            variants = groupEvidencesByCode(variants);
+            var mutationArray = [];
+                mutationArray.push({
+                    'type': 'VARIANT',
+                    'normal': '-',
+                    'pos': 0,
+                    'variants': []
+                });
+            var seq = sequence.split('');
+            _.each(seq, function(d, i) {
+                mutationArray.push({
+                    'type': 'VARIANT',
+                    'normal': seq[i],
+                    'pos': i + 1,
+                    'variants': []
+                });
+            });
+            mutationArray.push({
+                'type': 'VARIANT',
+                'normal': '-',
+                'pos': seq.length + 1,
+                'variants': []
+            });
+
+            _.each(variants, function(d) {
+                d.begin = +d.begin;
+                d.wildType = d.wildType ? d.wildType : mutationArray[d.begin].normal;
+                d.sourceType = d.sourceType.toLowerCase();
+                if ((1 <= d.begin) && (d.begin <= seq.length)) {
+                    mutationArray[d.begin].variants.push(d);
+                } else if ((seq.length + 1) === d.begin) {
+                    mutationArray[d.begin - 1].variants.push(d);
+                }
+            });
+          return [['VARIATION', mutationArray]];
+        }
+    };
 }();
 
 module.exports = DataLoader;

--- a/src/dataLoader.js
+++ b/src/dataLoader.js
@@ -71,7 +71,11 @@ var DataLoader = function() {
         processProteomics: function(features) {
             features = groupEvidencesByCode(features);
             var types = _.map(features, function(d){
-                d.unique ? d.type = 'unique' : d.type = 'non_unique';
+                if (d.unique) {
+                    d.type = 'unique';
+                } else {
+                    d.type = 'non_unique';
+                }
                 return d;
             });
             return [['PROTEOMICS',types]];


### PR DESCRIPTION
Group by evidence code, grouping is done at the data loader before any parsing. Then the tooltip goes throught the evidence codes.