### PR TITLE
Fix tooltip table width to 100%.

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -348,6 +348,7 @@ svg {
     -webkit-box-shadow: 5px 5px 2px 0px rgba(0, 0, 0, 0.1);
     -moz-box-shadow: 5px 5px 2px 0px rgba(0, 0, 0, 0.1);
     box-shadow: 5px 5px 2px 0px rgba(0, 0, 0, 0.1);
+    width: 100%;
 }
 
 .up_pftv_tooltip-container table th {


### PR DESCRIPTION
So even if it needs less than min-width it will go to min-width and the close button will be position on the top right of the min-width (at least).