### PR TITLE
Add BLAST option to tooltip.

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -6,6 +6,12 @@ var _ = require('underscore');
 
 var Constants = function() {
   return {
+    getBlastURL: function() {
+        return 'http://www.uniprot.org/blast/?about='
+    },
+    getNoBlastTypes: function() {
+      return ['helix', 'strand', 'turn', 'disulfid', 'crosslnk', 'variant'];
+    },
     getDataSources: function() {
       var sources = [{
         url: 'https://www.ebi.ac.uk/uniprot/api/features/',
@@ -117,8 +123,8 @@ var Constants = function() {
           variant: {label: 'Natural variant', tooltip: 'Natural variant of the protein, including polymorphisms, ' +
               'variations between strains, isolates or cultivars, disease-associated mutations and RNA editing events'
           },
-          unique:{label:'Unique peptides',tooltip:''},
-          non_unique:{label:'Non-unique peptides',tooltip:''}
+          unique:{label:'Unique peptide',tooltip:''},
+          non_unique:{label:'Non-unique peptide',tooltip:''}
       };
     }, getTrackInfo: function(name) {
       return this.getTrackNames()[name];

--- a/src/TooltipFactory.js
+++ b/src/TooltipFactory.js
@@ -6,6 +6,7 @@
 var d3 = require("d3");
 var _ = require("underscore");
 var Evidence = require('./Evidence');
+var Constants = require('./Constants');
 
 var createTooltipBox = function(container) {
     d3.select('.up_pftv_tooltip-container').remove();
@@ -235,8 +236,30 @@ Tooltip.prototype.addEvidences = function(evidences) {
     });
 };
 
+Tooltip.prototype.addBlast = function() {
+    var tooltip = this;
+    var end = tooltip.data.end ? tooltip.data.end : tooltip.data.begin;
+    var type = tooltip.data.type.toLowerCase();
+    if (((end - tooltip.data.begin) >= 3) && (!_.contains(Constants.getNoBlastTypes(), type))) {
+        var blast = tooltip.table.append('tr');
+        blast.append('td').text('Tools');
+        var url = Constants.getBlastURL() + tooltip.accession + '[' + tooltip.data.begin;
+        url += '-';
+        url += end + ']' + '&key=' + Constants.getTrackInfo(type).label;
+        if (tooltip.data.ftId) {
+            url += '&id=' + tooltip.data.ftId;
+        }
+        blast.append('td').append('span')
+            .append('a')
+            .attr('href', url)
+            .attr('target', '_blank')
+            .text('BLAST');
+    }
+};
+
 var BasicTooltipViewer = function(tooltip) {
     tooltip.addEvidences(tooltip.data.evidences);
+    tooltip.addBlast();
 };
 
 var AlternativeTooltipViewer = function(tooltip, change, field) {
@@ -252,6 +275,7 @@ var AlternativeTooltipViewer = function(tooltip, change, field) {
             });
     }
     tooltip.addEvidences(tooltip.data.evidences);
+    tooltip.addBlast();
 };
 
 var addPredictions = function(tooltip) {


### PR DESCRIPTION
* BLAST option is available only for those features not in Constants.getNoBlastTypes with at least 4 amino acides.
* BLAST links goes at the end of the tooltip.
* Not related but small change: Remove the plural for proteomics types as the other type are not in plural.